### PR TITLE
Freehand draw mode

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -49,7 +49,8 @@ module.exports = {
     DRAW_POINT: "draw_point",
     SIMPLE_SELECT: "simple_select",
     DIRECT_SELECT: "direct_select",
-    STATIC: "static"
+    STATIC: "static",
+    FREEHAND: "freehand"
   },
   events: {
     CREATE: "draw.create",

--- a/src/events.js
+++ b/src/events.js
@@ -80,6 +80,10 @@ module.exports = function (ctx) {
     ) {
       if (currentModeName !== 'freehand') currentMode.click(event);
     } else {
+      // Sometimes after entering freehand draw mode, if the user clicks while moving the mouse,
+      // a drag event will be fired, even though the mouse is not being held down. This causes
+      // event.featureTarget to be undefined and the draw mode to revert to normal polygon mode -
+      // so instead, we revert it to static here.
       if (event.featureTarget !== undefined) {
         currentMode.mouseup(event);
       } else if (currentModeName === 'freehand') {

--- a/src/events.js
+++ b/src/events.js
@@ -25,7 +25,7 @@ module.exports = function (ctx) {
     if (
       isDrag({
         point: event.point,
-        time: new Date().getTime()
+        time: new Date().getTime(),
       })
     ) {
       CM.setCursor(event, "drag");
@@ -37,11 +37,11 @@ module.exports = function (ctx) {
   };
 
   events.mousedrag = function (event) {
-    events.drag(event, endInfo => !isClick(mouseDownInfo, endInfo));
+    events.drag(event, (endInfo) => !isClick(mouseDownInfo, endInfo));
   };
 
   events.touchdrag = function (event) {
-    events.drag(event, endInfo => !isTap(touchStartInfo, endInfo));
+    events.drag(event, (endInfo) => !isTap(touchStartInfo, endInfo));
   };
 
   events.mousemove = function (event) {
@@ -52,7 +52,7 @@ module.exports = function (ctx) {
     if (button === 1) {
       return events.mousedrag(event);
     }
-    const target = CM.setCursor(event, 'mousemove');
+    const target = CM.setCursor(event, "mousemove");
     event.featureTarget = target;
     currentMode.mousemove(event);
   };
@@ -60,25 +60,25 @@ module.exports = function (ctx) {
   events.mousedown = function (event) {
     mouseDownInfo = {
       time: new Date().getTime(),
-      point: event.point
+      point: event.point,
     };
-    const target = CM.setCursor(event, 'mousedown');
+    const target = CM.setCursor(event, "mousedown");
 
     event.featureTarget = target;
     currentMode.mousedown(event);
   };
 
   events.mouseup = function (event) {
-    const target = CM.setCursor(event, 'mouseup');
+    const target = CM.setCursor(event, "mouseup");
     event.featureTarget = target;
 
     if (
       isClick(mouseDownInfo, {
         point: event.point,
-        time: new Date().getTime()
+        time: new Date().getTime(),
       })
     ) {
-      if (currentModeName !== 'freehand') currentMode.click(event);
+      if (currentModeName !== "freehand") currentMode.click(event);
     } else {
       // Sometimes after entering freehand draw mode, if the user clicks while moving the mouse,
       // a drag event will be fired, even though the mouse is not being held down. This causes
@@ -86,7 +86,7 @@ module.exports = function (ctx) {
       // so instead, we revert it to static here.
       if (event.featureTarget !== undefined) {
         currentMode.mouseup(event);
-      } else if (currentModeName === 'freehand') {
+      } else if (currentModeName === "freehand") {
         changeMode(Constants.modes.STATIC);
       }
     }
@@ -106,7 +106,7 @@ module.exports = function (ctx) {
 
     touchStartInfo = {
       time: new Date().getTime(),
-      point: event.point
+      point: event.point,
     };
     const target = featuresAt.touch(event, null, ctx)[0];
     event.featureTarget = target;
@@ -134,7 +134,7 @@ module.exports = function (ctx) {
     if (
       isTap(touchStartInfo, {
         time: new Date().getTime(),
-        point: event.point
+        point: event.point,
       })
     ) {
       currentMode.tap(event);
@@ -145,7 +145,7 @@ module.exports = function (ctx) {
 
   // 8 - Backspace
   // 46 - Delete
-  const isKeyModeValid = code =>
+  const isKeyModeValid = (code) =>
     !(code === 8 || code === 46 || (code >= 48 && code <= 57));
 
   events.keydown = function (event) {
@@ -182,7 +182,7 @@ module.exports = function (ctx) {
   events.data = function (event) {
     if (event.dataType === "style") {
       const { setup, map, options, store } = ctx;
-      const hasLayers = options.styles.some(style => map.getLayer(style.id));
+      const hasLayers = options.styles.some((style) => map.getLayer(style.id));
       if (!hasLayers) {
         setup.addLayers();
         store.setDirty();
@@ -192,18 +192,13 @@ module.exports = function (ctx) {
   };
 
   function changeMode(modename, nextModeOptions, eventOptions = {}) {
-
     // While freehand draw mode is active, the cursor should always be shown as a crosshair.
-    if (modename === 'freehand') {
-      ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
-      ctx.ui.updateMapClasses();
+    if (modename === "freehand") {
       CM.overrideGetCursorTypeLogic(() => Constants.cursors.ADD);
     }
     // Reset cursor if freehand draw mode is being exited.
-    if (currentModeName === 'freehand') {
+    if (currentModeName === "freehand") {
       CM.overrideGetCursorTypeLogic();
-      ctx.ui.queueMapClasses({ mouse: Constants.cursors.GRAB });
-      ctx.ui.updateMapClasses();
     }
 
     currentMode.stop();
@@ -225,12 +220,12 @@ module.exports = function (ctx) {
   const actionState = {
     trash: false,
     combineFeatures: false,
-    uncombineFeatures: false
+    uncombineFeatures: false,
   };
 
   function actionable(actions) {
     let changed = false;
-    Object.keys(actions).forEach(action => {
+    Object.keys(actions).forEach((action) => {
       if (actionState[action] === undefined)
         throw new Error("Invalid action type");
       if (actionState[action] !== actions[action]) changed = true;
@@ -303,7 +298,7 @@ module.exports = function (ctx) {
     },
     getMode() {
       return currentModeName;
-    }
+    },
   };
 
   return api;

--- a/src/events.js
+++ b/src/events.js
@@ -28,8 +28,7 @@ module.exports = function (ctx) {
         time: new Date().getTime()
       })
     ) {
-      CM.setCursor(event, "drag", currentModeName);
-
+      CM.setCursor(event, "drag");
       // ctx.ui.queueMapClasses({ mouse: Constants.cursors.DRAG });
       currentMode.drag(event);
     } else {
@@ -79,9 +78,13 @@ module.exports = function (ctx) {
         time: new Date().getTime()
       })
     ) {
-      currentMode.click(event);
+      if (currentModeName !== 'freehand') currentMode.click(event);
     } else {
-      currentMode.mouseup(event);
+      if (event.featureTarget !== undefined) {
+        currentMode.mouseup(event);
+      } else if (currentModeName === 'freehand') {
+        changeMode(Constants.modes.STATIC);
+      }
     }
   };
 

--- a/src/events.js
+++ b/src/events.js
@@ -78,7 +78,9 @@ module.exports = function (ctx) {
         time: new Date().getTime(),
       })
     ) {
-      if (currentModeName !== "freehand") currentMode.click(event);
+      if (currentModeName !== "freehand") {
+        currentMode.click(event);
+      }
     } else {
       // Sometimes after entering freehand draw mode, if the user clicks while moving the mouse,
       // a drag event will be fired, even though the mouse is not being held down. This causes

--- a/src/events.js
+++ b/src/events.js
@@ -199,6 +199,8 @@ module.exports = function (ctx) {
       ctx.ui.updateMapClasses();
     }
 
+    currentMode.stop();
+
     const modebuilder = modes[modename];
     if (modebuilder === undefined) {
       throw new Error(`${modename} is not valid`);

--- a/src/events.js
+++ b/src/events.js
@@ -28,7 +28,7 @@ module.exports = function (ctx) {
         time: new Date().getTime()
       })
     ) {
-      CM.setCursor(event, "drag");
+      CM.setCursor(event, "drag", currentModeName);
 
       // ctx.ui.queueMapClasses({ mouse: Constants.cursors.DRAG });
       currentMode.drag(event);
@@ -53,7 +53,7 @@ module.exports = function (ctx) {
     if (button === 1) {
       return events.mousedrag(event);
     }
-    const target = CM.setCursor(event, 'mousemove');
+    const target = CM.setCursor(event, 'mousemove', currentModeName);
     event.featureTarget = target;
     currentMode.mousemove(event);
   };
@@ -185,7 +185,16 @@ module.exports = function (ctx) {
   };
 
   function changeMode(modename, nextModeOptions, eventOptions = {}) {
-    currentMode.stop();
+
+    // While freehand draw mode is active, the cursor should always be shown as a crosshair.
+    if (modename === 'freehand') {
+      ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
+      ctx.ui.updateMapClasses();
+      CM.overrideGetCursorTypeLogic(() => Constants.cursors.ADD);
+    } else {
+      CM.overrideGetCursorTypeLogic();
+      ctx.ui.updateMapClasses();
+    }
 
     const modebuilder = modes[modename];
     if (modebuilder === undefined) {

--- a/src/events.js
+++ b/src/events.js
@@ -191,8 +191,11 @@ module.exports = function (ctx) {
       ctx.ui.queueMapClasses({ mouse: Constants.cursors.ADD });
       ctx.ui.updateMapClasses();
       CM.overrideGetCursorTypeLogic(() => Constants.cursors.ADD);
-    } else {
+    }
+    // Reset cursor if freehand draw mode is being exited.
+    if (currentModeName === 'freehand') {
       CM.overrideGetCursorTypeLogic();
+      ctx.ui.queueMapClasses({ mouse: Constants.cursors.GRAB });
       ctx.ui.updateMapClasses();
     }
 

--- a/src/events.js
+++ b/src/events.js
@@ -52,7 +52,7 @@ module.exports = function (ctx) {
     if (button === 1) {
       return events.mousedrag(event);
     }
-    const target = CM.setCursor(event, 'mousemove', currentModeName);
+    const target = CM.setCursor(event, 'mousemove');
     event.featureTarget = target;
     currentMode.mousemove(event);
   };

--- a/src/lib/cursor.js
+++ b/src/lib/cursor.js
@@ -29,15 +29,15 @@ class CursorManager {
       .filter(l => !l.layer.id.includes("snap"));
 
     let cursorType
-    if(eventType === 'drag'){
-      cursorType = cursors.GRABBING
+    if(this.overridedGetCursorType){
+      cursorType = this.overridedGetCursorType({
+        snapped: this.snapped,
+        isOverSelected: Boolean(glDrawFeats[0]),
+        overFeatures: allFeatures.length > 0 ? allFeatures : null
+      })
     } else {
-      if(this.overridedGetCursorType){
-        cursorType = this.overridedGetCursorType({
-          snapped: this.snapped,
-          isOverSelected: Boolean(glDrawFeats[0]),
-          overFeatures: allFeatures.length > 0 ? allFeatures : null
-        })
+      if(eventType === 'drag'){
+        cursorType = cursors.GRABBING
       }else{
         cursorType =
           this.getCursorType ?

--- a/src/modes/freehand.js
+++ b/src/modes/freehand.js
@@ -3,7 +3,7 @@ const { geojsonTypes, cursors, types, updateActions, modes, events } =  require(
 const doubleClickZoom = require('../lib/double_click_zoom');
 const simplify = require('@turf/simplify').default;
 
-const FreeDraw = Object.assign({}, DrawPolygon)
+const { onMouseMove, ...FreeDraw } = Object.assign({}, DrawPolygon)
 
 FreeDraw.onSetup = function() {
     const polygon = this.newFeature({

--- a/src/modes/freehand.js
+++ b/src/modes/freehand.js
@@ -28,8 +28,6 @@ FreeDraw.onSetup = function() {
         this.map.dragPan.disable();
     }, 0);
 
-    this.updateUIClasses({ mouse: cursors.ADD });
-    this.activateUIButton(types.POLYGON);
     this.setActionableState({
         trash: true
     });
@@ -43,7 +41,6 @@ FreeDraw.onSetup = function() {
 
 FreeDraw.onDrag = FreeDraw.onTouchMove = function (state, e){
     state.dragMoving = true;
-    this.updateUIClasses({ mouse: cursors.ADD });
     state.polygon.updateCoordinate(`0.${state.currentVertexPosition}`, e.lngLat.lng, e.lngLat.lat);
     state.currentVertexPosition++;
     state.polygon.updateCoordinate(`0.${state.currentVertexPosition}`, e.lngLat.lng, e.lngLat.lat);

--- a/src/modes/freehand.js
+++ b/src/modes/freehand.js
@@ -1,75 +1,98 @@
-const DrawPolygon = require('./draw_polygon');
-const { geojsonTypes, cursors, types, updateActions, modes, events } =  require('../constants');
-const doubleClickZoom = require('../lib/double_click_zoom');
-const simplify = require('@turf/simplify').default;
+// This draw mode is copied from this module: https://github.com/bemky/mapbox-gl-draw-freehand-mode
+// with a couple of minor tweaks:
+//
+// - clearSelectedFeatures() is called on mouseup event to remove the interactable vertices from the final polygon.
+// - DrawPolygon's onMouseMove is not assigned to the FreeDraw object. Without this change, it becomes possible
+//   (under rare circumstances) to enter a state in which the polygon is drawn by placing each vertex individually.
+// - cursor UI updates are removed, as this is handled in src/events.js.
 
-const { onMouseMove, ...FreeDraw } = Object.assign({}, DrawPolygon)
+const DrawPolygon = require("./draw_polygon");
+const {
+  geojsonTypes,
+  cursors,
+  types,
+  updateActions,
+  modes,
+  events,
+} = require("../constants");
+const doubleClickZoom = require("../lib/double_click_zoom");
+const simplify = require("@turf/simplify").default;
 
-FreeDraw.onSetup = function() {
-    const polygon = this.newFeature({
-        type: geojsonTypes.FEATURE,
-        properties: {},
-        geometry: {
-            type: geojsonTypes.POLYGON,
-            coordinates: [[]]
-        },
-        // The id of the freedrawn polygon is explicitly set, so we can tell simple_select's click handler
-        // not to do anything with this feature.
-        id: 'freehand'
+const { onMouseMove, ...FreeDraw } = Object.assign({}, DrawPolygon);
+
+FreeDraw.onSetup = function () {
+  const polygon = this.newFeature({
+    type: geojsonTypes.FEATURE,
+    properties: {},
+    geometry: {
+      type: geojsonTypes.POLYGON,
+      coordinates: [[]],
+    },
+    // The id of the freedrawn polygon is explicitly set, so we can tell simple_select's click handler
+    // not to do anything with this feature.
+    id: "freehand",
+  });
+
+  this.addFeature(polygon);
+
+  this.clearSelectedFeatures();
+  doubleClickZoom.disable(this);
+  // disable dragPan
+  setTimeout(() => {
+    if (!this.map || !this.map.dragPan) return;
+    this.map.dragPan.disable();
+  }, 0);
+
+  this.setActionableState({
+    trash: true,
+  });
+
+  return {
+    polygon,
+    currentVertexPosition: 0,
+    dragMoving: false,
+  };
+};
+
+FreeDraw.onDrag = FreeDraw.onTouchMove = function (state, e) {
+  state.dragMoving = true;
+  state.polygon.updateCoordinate(
+    `0.${state.currentVertexPosition}`,
+    e.lngLat.lng,
+    e.lngLat.lat
+  );
+  state.currentVertexPosition++;
+  state.polygon.updateCoordinate(
+    `0.${state.currentVertexPosition}`,
+    e.lngLat.lng,
+    e.lngLat.lat
+  );
+};
+
+FreeDraw.onMouseUp = function (state, e) {
+  if (state.dragMoving) {
+    var tolerance = 3 / ((this.map.getZoom() - 4) * 150) - 0.001; // https://www.desmos.com/calculator/b3zi8jqskw
+    simplify(state.polygon, {
+      mutate: true,
+      tolerance: tolerance,
+      highQuality: true,
     });
 
-    this.addFeature(polygon);
-
+    this.fireUpdate();
+    this.changeMode(modes.SIMPLE_SELECT, { featureIds: [state.polygon.id] });
     this.clearSelectedFeatures();
-    doubleClickZoom.disable(this);
-    // disable dragPan
-    setTimeout(() => {
-        if (!this.map || !this.map.dragPan) return;
-        this.map.dragPan.disable();
-    }, 0);
-
-    this.setActionableState({
-        trash: true
-    });
-
-    return {
-        polygon,
-        currentVertexPosition: 0,
-        dragMoving: false
-    };
+  }
 };
 
-FreeDraw.onDrag = FreeDraw.onTouchMove = function (state, e){
-    state.dragMoving = true;
-    state.polygon.updateCoordinate(`0.${state.currentVertexPosition}`, e.lngLat.lng, e.lngLat.lat);
-    state.currentVertexPosition++;
-    state.polygon.updateCoordinate(`0.${state.currentVertexPosition}`, e.lngLat.lng, e.lngLat.lat);
-}
-
-FreeDraw.onMouseUp = function (state, e){
-    if (state.dragMoving) {
-        var tolerance = (3 / ((this.map.getZoom()-4) * 150)) - 0.001 // https://www.desmos.com/calculator/b3zi8jqskw
-        simplify(state.polygon, {
-            mutate: true,
-            tolerance: tolerance,
-            highQuality: true
-        });
-
-        this.fireUpdate();
-        this.changeMode(modes.SIMPLE_SELECT, { featureIds: [state.polygon.id] });
-        this.clearSelectedFeatures();
-    }
-}
-
-FreeDraw.onTouchEnd = function(state, e) {
-    this.onMouseUp(state, e)
-}
-
-FreeDraw.fireUpdate = function() {
-    this.map.fire(events.UPDATE, {
-        action: updateActions.MOVE,
-        features: this.getSelected().map(f => f.toGeoJSON())
-    });
+FreeDraw.onTouchEnd = function (state, e) {
+  this.onMouseUp(state, e);
 };
 
-module.exports = FreeDraw
+FreeDraw.fireUpdate = function () {
+  this.map.fire(events.UPDATE, {
+    action: updateActions.MOVE,
+    features: this.getSelected().map((f) => f.toGeoJSON()),
+  });
+};
+
+module.exports = FreeDraw;

--- a/src/modes/freehand.js
+++ b/src/modes/freehand.js
@@ -12,7 +12,10 @@ FreeDraw.onSetup = function() {
         geometry: {
             type: geojsonTypes.POLYGON,
             coordinates: [[]]
-        }
+        },
+        // The id of the freedrawn polygon is explicitly set, so we can tell simple_select's click handler
+        // not to do anything with this feature.
+        id: 'freehand'
     });
 
     this.addFeature(polygon);

--- a/src/modes/freehand.js
+++ b/src/modes/freehand.js
@@ -1,0 +1,75 @@
+const DrawPolygon = require('./draw_polygon');
+const { geojsonTypes, cursors, types, updateActions, modes, events } =  require('../constants');
+const doubleClickZoom = require('../lib/double_click_zoom');
+const simplify = require('@turf/simplify').default;
+
+const FreeDraw = Object.assign({}, DrawPolygon)
+
+FreeDraw.onSetup = function() {
+    const polygon = this.newFeature({
+        type: geojsonTypes.FEATURE,
+        properties: {},
+        geometry: {
+            type: geojsonTypes.POLYGON,
+            coordinates: [[]]
+        }
+    });
+
+    this.addFeature(polygon);
+
+    this.clearSelectedFeatures();
+    doubleClickZoom.disable(this);
+    // disable dragPan
+    setTimeout(() => {
+        if (!this.map || !this.map.dragPan) return;
+        this.map.dragPan.disable();
+    }, 0);
+
+    this.updateUIClasses({ mouse: cursors.ADD });
+    this.activateUIButton(types.POLYGON);
+    this.setActionableState({
+        trash: true
+    });
+
+    return {
+        polygon,
+        currentVertexPosition: 0,
+        dragMoving: false
+    };
+};
+
+FreeDraw.onDrag = FreeDraw.onTouchMove = function (state, e){
+    state.dragMoving = true;
+    this.updateUIClasses({ mouse: cursors.ADD });
+    state.polygon.updateCoordinate(`0.${state.currentVertexPosition}`, e.lngLat.lng, e.lngLat.lat);
+    state.currentVertexPosition++;
+    state.polygon.updateCoordinate(`0.${state.currentVertexPosition}`, e.lngLat.lng, e.lngLat.lat);
+}
+
+FreeDraw.onMouseUp = function (state, e){
+    if (state.dragMoving) {
+        var tolerance = (3 / ((this.map.getZoom()-4) * 150)) - 0.001 // https://www.desmos.com/calculator/b3zi8jqskw
+        simplify(state.polygon, {
+            mutate: true,
+            tolerance: tolerance,
+            highQuality: true
+        });
+
+        this.fireUpdate();
+        this.changeMode(modes.SIMPLE_SELECT, { featureIds: [state.polygon.id] });
+        this.clearSelectedFeatures();
+    }
+}
+
+FreeDraw.onTouchEnd = function(state, e) {
+    this.onMouseUp(state, e)
+}
+
+FreeDraw.fireUpdate = function() {
+    this.map.fire(events.UPDATE, {
+        action: updateActions.MOVE,
+        features: this.getSelected().map(f => f.toGeoJSON())
+    });
+};
+
+module.exports = FreeDraw

--- a/src/modes/index.js
+++ b/src/modes/index.js
@@ -5,5 +5,6 @@ module.exports = {
   draw_polygon: require("./draw_polygon"),
   draw_line_string: require("./draw_line_string"),
   split: require("./split"),
-  coincident_select: require("./coincident_select")
+  coincident_select: require("./coincident_select"),
+  freehand: require("./freehand")
 };

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -185,6 +185,9 @@ SimpleSelect.startOnActiveFeature = function (state, e) {
 };
 
 SimpleSelect.clickOnFeature = function (state, e) {
+  // This prevents a polygon drawn in freehand mode from being resized/moved.
+  if (e.featureTarget.properties.id === 'freehand') return;
+
   // Stop everything
   doubleClickZoom.disable(this);
   this.stopExtendedInteractions(state);


### PR DESCRIPTION
[#174510266](https://www.pivotaltracker.com/story/show/174510266)

[Frontend PR](https://github.com/NBTSolutions/vetro-2-front-end/pull/270)
[Backend PR](https://github.com/NBTSolutions/backend-vetro2/pull/258)

Adds a freehand draw mode for lasso select.

What's in `freehand.js` is (mostly) from this [node module](https://github.com/bemky/mapbox-gl-draw-freehand-mode) - I copied it in to modify it a bit.
