### PR TITLE
Draw freehand polygon

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -46,6 +46,7 @@ module.exports = {
   modes: {
     DRAW_LINE_STRING: "draw_line_string",
     DRAW_POLYGON: "draw_polygon",
+    DRAW_FREEHAND_POLYGON: "draw_freehand_polygon",
     DRAW_POINT: "draw_point",
     SIMPLE_SELECT: "simple_select",
     DIRECT_SELECT: "direct_select",

--- a/src/events.js
+++ b/src/events.js
@@ -69,7 +69,6 @@ module.exports = function (ctx) {
   };
 
   events.mouseup = function (event) {
-    console.log('mouse up in event', event);
     const target = CM.setCursor(event, "mouseup");
     event.featureTarget = target;
 

--- a/src/events.js
+++ b/src/events.js
@@ -69,6 +69,7 @@ module.exports = function (ctx) {
   };
 
   events.mouseup = function (event) {
+    console.log('mouse up in event', event);
     const target = CM.setCursor(event, "mouseup");
     event.featureTarget = target;
 
@@ -82,15 +83,18 @@ module.exports = function (ctx) {
         currentMode.click(event);
       }
     } else {
+      currentMode.mouseup(event);
       // Sometimes after entering a group select mode, if the user clicks while moving the mouse,
       // a drag event will be fired, even though the mouse is not being held down. This causes
       // event.featureTarget to be undefined and the draw mode to revert to normal polygon mode -
       // so instead, we revert it to static here.
-      if (event.featureTarget !== undefined) {
+      // I don't think this is needed since we force the user to hold the mouse button down
+      // when creating a group selection --Kyle
+      /* if (event.featureTarget !== undefined) {
         currentMode.mouseup(event);
       } else if (Constants.groupSelectModes.includes(currentModeName)) {
         changeMode(Constants.modes.STATIC);
-      }
+      } */
     }
   };
 

--- a/src/modes/draw_freehand_polygon.js
+++ b/src/modes/draw_freehand_polygon.js
@@ -58,7 +58,6 @@ DrawFreehandPolygon.onDrag = DrawFreehandPolygon.onTouchMove = function (state, 
 };
 
 DrawFreehandPolygon.onMouseUp = function (state, e) {
-  console.log('mouse up in draw freehand polygon', state.dragMoving);
   if (state.dragMoving) {
     var tolerance = 3 / ((this.map.getZoom() - 4) * 150) - 0.001; // https://www.desmos.com/calculator/b3zi8jqskw
     simplify(state.polygon, {

--- a/src/modes/draw_freehand_polygon.js
+++ b/src/modes/draw_freehand_polygon.js
@@ -43,7 +43,6 @@ DrawFreehandPolygon.onSetup = function (opts = {}) {
 };
 
 DrawFreehandPolygon.onDrag = DrawFreehandPolygon.onTouchMove = function (state, e) {
-  e.preventDefault();
   state.dragMoving = true;
   state.polygon.updateCoordinate(
     `0.${state.currentVertexPosition}`,
@@ -58,9 +57,8 @@ DrawFreehandPolygon.onDrag = DrawFreehandPolygon.onTouchMove = function (state, 
   );
 };
 
-DrawFreehandPolygon.onDragEnd = DrawFreehandPolygon.onMouseUp = function (state, e) {
-  e.preventDefault();
-  console.log('mouse up', state.dragMoving);
+DrawFreehandPolygon.onMouseUp = function (state, e) {
+  console.log('mouse up in draw freehand polygon', state.dragMoving);
   if (state.dragMoving) {
     var tolerance = 3 / ((this.map.getZoom() - 4) * 150) - 0.001; // https://www.desmos.com/calculator/b3zi8jqskw
     simplify(state.polygon, {

--- a/src/modes/draw_freehand_polygon.js
+++ b/src/modes/draw_freehand_polygon.js
@@ -1,242 +1,90 @@
-const CommonSelectors = require("../lib/common_selectors");
+const DrawPolygon = require("./draw_polygon");
+const {
+  geojsonTypes,
+  updateActions,
+  modes,
+  events,
+} = require("../constants");
 const doubleClickZoom = require("../lib/double_click_zoom");
-const Constants = require("../constants");
-const isEventAtCoordinates = require("../lib/is_event_at_coordinates");
-const createVertex = require("../lib/create_vertex");
-const cursors = Constants.cursors;
+const simplify = require("@turf/simplify").default;
 
+const { onMouseMove, ...DrawFreehandPolygon } = Object.assign({}, DrawPolygon);
 
-const DrawPolygon = {};
-
-DrawPolygon.onSetup = function(opts) {
-  if (this._ctx.snapping) {
-    this._ctx.snapping.setSnapToSelected(false);
-  }
-
-  this._ctx.setGetCursorTypeLogic(({ snapped }) => {
-    if (snapped) {
-      return cursors.ADD;
-    } else {
-      return cursors.POINTER;
-    }
-  });
-
+DrawFreehandPolygon.onSetup = function (opts) {
   const polygon = this.newFeature({
-    type: Constants.geojsonTypes.FEATURE,
+    type: geojsonTypes.FEATURE,
     properties: {},
     geometry: {
-      type: Constants.geojsonTypes.POLYGON,
-      coordinates: [[]]
-    }
+      type: geojsonTypes.POLYGON,
+      coordinates: [[]],
+    },
   });
 
   this.addFeature(polygon);
 
   this.clearSelectedFeatures();
   doubleClickZoom.disable(this);
-  this.updateUIClasses({ mouse: Constants.cursors.ADD });
-  this.activateUIButton(Constants.types.POLYGON);
+  // disable dragPan
+  setTimeout(() => {
+    if (!this.map || !this.map.dragPan) return;
+    this.map.dragPan.disable();
+  });
+
   this.setActionableState({
-    trash: true
+    trash: true,
   });
 
   return {
     polygon,
     currentVertexPosition: 0,
-    redraw: opts.redraw,
-    previousFeatureId: opts.previousFeatureId,
-    multiple: opts.multiple,
+    dragMoving: false,
   };
 };
 
-DrawPolygon.clickAnywhere = function(state, e) {
-  if (
-    state.currentVertexPosition > 0 &&
-    isEventAtCoordinates(
-      e,
-      state.polygon.coordinates[0][state.currentVertexPosition - 1]
-    )
-  ) {
-    return this.changeMode(Constants.modes.SIMPLE_SELECT, {
-      featureIds: [state.polygon.id]
-    });
-  }
-  this.updateUIClasses({ mouse: Constants.cursors.ADD });
-  const lngLat = this._ctx.snapping.snapCoord(e);
+DrawFreehandPolygon.onDrag = DrawFreehandPolygon.onTouchMove = function (state, e) {
+  state.dragMoving = true;
   state.polygon.updateCoordinate(
     `0.${state.currentVertexPosition}`,
-    lngLat.lng,
-    lngLat.lat
+    e.lngLat.lng,
+    e.lngLat.lat
   );
   state.currentVertexPosition++;
   state.polygon.updateCoordinate(
     `0.${state.currentVertexPosition}`,
-    lngLat.lng,
-    lngLat.lat
+    e.lngLat.lng,
+    e.lngLat.lat
   );
+};
 
-  this.map.fire(Constants.events.VERTEX_PLACED, { features: [state.polygon.toGeoJSON()] });
-
-  if (state.polygon.isCreatingValid()) {
-    this.map.fire(Constants.events.CREATING, {
-      features: [state.polygon.toGeoJSON(true)]
+DrawFreehandPolygon.onMouseUp = function (state, e) {
+  if (state.dragMoving) {
+    var tolerance = 3 / ((this.map.getZoom() - 4) * 150) - 0.001; // https://www.desmos.com/calculator/b3zi8jqskw
+    simplify(state.polygon, {
+      mutate: true,
+      tolerance: tolerance,
+      highQuality: true,
     });
+
+    if (state.polygon.isValid()) {
+      this.map.fire(events.CREATE, {
+        features: [state.polygon.toGeoJSON()]
+      });
+    }
+    // this.fireUpdate();
+    // this.changeMode(modes.SIMPLE_SELECT, { featureIds: [state.polygon.id] });
+    // this.clearSelectedFeatures();
   }
 };
 
-DrawPolygon.clickOnVertex = function(state) {
-  if (state.redraw) {
-    return this.changeMode(Constants.modes.DRAW_POLYGON, {
-      previousFeatureId: state.polygon.id,
-      redraw: true
-    });
-  }
+DrawFreehandPolygon.onTouchEnd = function (state, e) {
+  this.onMouseUp(state, e);
+};
 
-  if (state.multiple) {
-    return this.changeMode(Constants.modes.DRAW_POLYGON, { multiple: true });
-  }
-
-  return this.changeMode(Constants.modes.SIMPLE_SELECT, {
-    featureIds: [state.polygon.id]
+DrawFreehandPolygon.fireUpdate = function () {
+  this.map.fire(events.UPDATE, {
+    action: updateActions.MOVE,
+    features: this.getSelected().map((f) => f.toGeoJSON()),
   });
 };
 
-DrawPolygon.onMouseMove = function(state, e) {
-  const lngLat = this._ctx.snapping.snapCoord(e);
-  state.polygon.updateCoordinate(
-    `0.${state.currentVertexPosition}`,
-    lngLat.lng,
-    lngLat.lat
-  );
-  if (CommonSelectors.isVertex(e)) {
-    this.updateUIClasses({ mouse: Constants.cursors.POINTER });
-  }
-};
-
-DrawPolygon.onTap = DrawPolygon.onClick = function(state, e) {
-  // delete previously drawn polygon if it exists
-  if (state.redraw && state.previousFeatureId) {
-    this.deleteFeature(state.previousFeatureId, { silent: true });
-  }
-
-  if (CommonSelectors.isVertex(e)) return this.clickOnVertex(state, e);
-  return this.clickAnywhere(state, e);
-};
-
-DrawPolygon.onKeyUp = function(state, e) {
-  if (state.redraw) return;
-
-  if (CommonSelectors.isEscapeKey(e)) {
-    this.deleteFeature([state.polygon.id], { silent: true });
-    this.changeMode(Constants.modes.SIMPLE_SELECT);
-  } else if (CommonSelectors.isEnterKey(e)) {
-    this.changeMode(Constants.modes.SIMPLE_SELECT, {
-      featureIds: [state.polygon.id]
-    });
-  }
-};
-
-DrawPolygon.onStop = function(state) {
-  this.updateUIClasses({ mouse: Constants.cursors.NONE });
-  doubleClickZoom.enable(this);
-  this.activateUIButton();
-
-  // check to see if we've deleted this feature
-  if (this.getFeature(state.polygon.id) === undefined) return;
-
-  //remove last added coordinate
-  state.polygon.removeCoordinate(`0.${state.currentVertexPosition}`);
-  if (state.multiple && state.polygon.isValid()) {
-    const allFeatures = state.polygon.ctx.store._features;
-
-    this.map.fire(Constants.events.CREATE, {
-      features: Object.keys(allFeatures).map(featureId => allFeatures[featureId].toGeoJSON()),
-      newFeature: [state.polygon.toGeoJSON()]
-    });
-  } else if (state.polygon.isValid()) {
-    this.map.fire(Constants.events.CREATE, {
-      features: [state.polygon.toGeoJSON()]
-    });
-  } else {
-    this.deleteFeature([state.polygon.id], { silent: true });
-    this.changeMode(Constants.modes.SIMPLE_SELECT, {}, { silent: true });
-  }
-};
-
-DrawPolygon.toDisplayFeatures = function(state, geojson, display) {
-  const isActivePolygon = geojson.properties.id === state.polygon.id;
-  geojson.properties.active = isActivePolygon
-    ? Constants.activeStates.ACTIVE
-    : Constants.activeStates.INACTIVE;
-  if (!isActivePolygon) return display(geojson);
-
-  // Don't render a polygon until it has two positions
-  // (and a 3rd which is just the first repeated)
-  if (geojson.geometry.coordinates.length === 0) return;
-
-  const coordinateCount = geojson.geometry.coordinates[0].length;
-  // 2 coordinates after selecting a draw type
-  // 3 after creating the first point
-  if (coordinateCount < 3) {
-    return;
-  }
-  geojson.properties.meta = Constants.meta.FEATURE;
-  display(
-    createVertex(
-      state.polygon.id,
-      geojson.geometry.coordinates[0][0],
-      "0.0",
-      false
-    )
-  );
-  if (coordinateCount > 3) {
-    // Add a start position marker to the map, clicking on this will finish the feature
-    // This should only be shown when we're in a valid spot
-    const endPos = geojson.geometry.coordinates[0].length - 3;
-    display(
-      createVertex(
-        state.polygon.id,
-        geojson.geometry.coordinates[0][endPos],
-        `0.${endPos}`,
-        false
-      )
-    );
-  }
-  if (coordinateCount <= 4) {
-    // If we've only drawn two positions (plus the closer),
-    // make a LineString instead of a Polygon
-    const lineCoordinates = [
-      [
-        geojson.geometry.coordinates[0][0][0],
-        geojson.geometry.coordinates[0][0][1]
-      ],
-      [
-        geojson.geometry.coordinates[0][1][0],
-        geojson.geometry.coordinates[0][1][1]
-      ]
-    ];
-    // create an initial vertex so that we can track the first point on mobile devices
-    display({
-      type: Constants.geojsonTypes.FEATURE,
-      properties: geojson.properties,
-      geometry: {
-        coordinates: lineCoordinates,
-        type: Constants.geojsonTypes.LINE_STRING
-      }
-    });
-    if (coordinateCount === 3) {
-      return;
-    }
-  }
-  // render the Polygon
-  return display(geojson);
-};
-
-DrawPolygon.onTrash = function(state) {
-  if (state.redraw) return;
-
-  this.deleteFeature([state.polygon.id], { silent: true });
-  this.changeMode(Constants.modes.SIMPLE_SELECT);
-};
-
-module.exports = DrawPolygon;
+module.exports = DrawFreehandPolygon;

--- a/src/modes/draw_freehand_polygon.js
+++ b/src/modes/draw_freehand_polygon.js
@@ -59,7 +59,7 @@ DrawFreehandPolygon.onDrag = DrawFreehandPolygon.onTouchMove = function (state, 
 
 DrawFreehandPolygon.onMouseUp = function (state, e) {
   if (state.dragMoving) {
-    var tolerance = 3 / ((this.map.getZoom() - 4) * 150) - 0.001; // https://www.desmos.com/calculator/b3zi8jqskw
+    const tolerance = 3 / ((this.map.getZoom() - 4) * 150) - 0.001; // https://www.desmos.com/calculator/b3zi8jqskw
     simplify(state.polygon, {
       mutate: true,
       tolerance: tolerance,

--- a/src/modes/draw_freehand_polygon.js
+++ b/src/modes/draw_freehand_polygon.js
@@ -1,0 +1,242 @@
+const CommonSelectors = require("../lib/common_selectors");
+const doubleClickZoom = require("../lib/double_click_zoom");
+const Constants = require("../constants");
+const isEventAtCoordinates = require("../lib/is_event_at_coordinates");
+const createVertex = require("../lib/create_vertex");
+const cursors = Constants.cursors;
+
+
+const DrawPolygon = {};
+
+DrawPolygon.onSetup = function(opts) {
+  if (this._ctx.snapping) {
+    this._ctx.snapping.setSnapToSelected(false);
+  }
+
+  this._ctx.setGetCursorTypeLogic(({ snapped }) => {
+    if (snapped) {
+      return cursors.ADD;
+    } else {
+      return cursors.POINTER;
+    }
+  });
+
+  const polygon = this.newFeature({
+    type: Constants.geojsonTypes.FEATURE,
+    properties: {},
+    geometry: {
+      type: Constants.geojsonTypes.POLYGON,
+      coordinates: [[]]
+    }
+  });
+
+  this.addFeature(polygon);
+
+  this.clearSelectedFeatures();
+  doubleClickZoom.disable(this);
+  this.updateUIClasses({ mouse: Constants.cursors.ADD });
+  this.activateUIButton(Constants.types.POLYGON);
+  this.setActionableState({
+    trash: true
+  });
+
+  return {
+    polygon,
+    currentVertexPosition: 0,
+    redraw: opts.redraw,
+    previousFeatureId: opts.previousFeatureId,
+    multiple: opts.multiple,
+  };
+};
+
+DrawPolygon.clickAnywhere = function(state, e) {
+  if (
+    state.currentVertexPosition > 0 &&
+    isEventAtCoordinates(
+      e,
+      state.polygon.coordinates[0][state.currentVertexPosition - 1]
+    )
+  ) {
+    return this.changeMode(Constants.modes.SIMPLE_SELECT, {
+      featureIds: [state.polygon.id]
+    });
+  }
+  this.updateUIClasses({ mouse: Constants.cursors.ADD });
+  const lngLat = this._ctx.snapping.snapCoord(e);
+  state.polygon.updateCoordinate(
+    `0.${state.currentVertexPosition}`,
+    lngLat.lng,
+    lngLat.lat
+  );
+  state.currentVertexPosition++;
+  state.polygon.updateCoordinate(
+    `0.${state.currentVertexPosition}`,
+    lngLat.lng,
+    lngLat.lat
+  );
+
+  this.map.fire(Constants.events.VERTEX_PLACED, { features: [state.polygon.toGeoJSON()] });
+
+  if (state.polygon.isCreatingValid()) {
+    this.map.fire(Constants.events.CREATING, {
+      features: [state.polygon.toGeoJSON(true)]
+    });
+  }
+};
+
+DrawPolygon.clickOnVertex = function(state) {
+  if (state.redraw) {
+    return this.changeMode(Constants.modes.DRAW_POLYGON, {
+      previousFeatureId: state.polygon.id,
+      redraw: true
+    });
+  }
+
+  if (state.multiple) {
+    return this.changeMode(Constants.modes.DRAW_POLYGON, { multiple: true });
+  }
+
+  return this.changeMode(Constants.modes.SIMPLE_SELECT, {
+    featureIds: [state.polygon.id]
+  });
+};
+
+DrawPolygon.onMouseMove = function(state, e) {
+  const lngLat = this._ctx.snapping.snapCoord(e);
+  state.polygon.updateCoordinate(
+    `0.${state.currentVertexPosition}`,
+    lngLat.lng,
+    lngLat.lat
+  );
+  if (CommonSelectors.isVertex(e)) {
+    this.updateUIClasses({ mouse: Constants.cursors.POINTER });
+  }
+};
+
+DrawPolygon.onTap = DrawPolygon.onClick = function(state, e) {
+  // delete previously drawn polygon if it exists
+  if (state.redraw && state.previousFeatureId) {
+    this.deleteFeature(state.previousFeatureId, { silent: true });
+  }
+
+  if (CommonSelectors.isVertex(e)) return this.clickOnVertex(state, e);
+  return this.clickAnywhere(state, e);
+};
+
+DrawPolygon.onKeyUp = function(state, e) {
+  if (state.redraw) return;
+
+  if (CommonSelectors.isEscapeKey(e)) {
+    this.deleteFeature([state.polygon.id], { silent: true });
+    this.changeMode(Constants.modes.SIMPLE_SELECT);
+  } else if (CommonSelectors.isEnterKey(e)) {
+    this.changeMode(Constants.modes.SIMPLE_SELECT, {
+      featureIds: [state.polygon.id]
+    });
+  }
+};
+
+DrawPolygon.onStop = function(state) {
+  this.updateUIClasses({ mouse: Constants.cursors.NONE });
+  doubleClickZoom.enable(this);
+  this.activateUIButton();
+
+  // check to see if we've deleted this feature
+  if (this.getFeature(state.polygon.id) === undefined) return;
+
+  //remove last added coordinate
+  state.polygon.removeCoordinate(`0.${state.currentVertexPosition}`);
+  if (state.multiple && state.polygon.isValid()) {
+    const allFeatures = state.polygon.ctx.store._features;
+
+    this.map.fire(Constants.events.CREATE, {
+      features: Object.keys(allFeatures).map(featureId => allFeatures[featureId].toGeoJSON()),
+      newFeature: [state.polygon.toGeoJSON()]
+    });
+  } else if (state.polygon.isValid()) {
+    this.map.fire(Constants.events.CREATE, {
+      features: [state.polygon.toGeoJSON()]
+    });
+  } else {
+    this.deleteFeature([state.polygon.id], { silent: true });
+    this.changeMode(Constants.modes.SIMPLE_SELECT, {}, { silent: true });
+  }
+};
+
+DrawPolygon.toDisplayFeatures = function(state, geojson, display) {
+  const isActivePolygon = geojson.properties.id === state.polygon.id;
+  geojson.properties.active = isActivePolygon
+    ? Constants.activeStates.ACTIVE
+    : Constants.activeStates.INACTIVE;
+  if (!isActivePolygon) return display(geojson);
+
+  // Don't render a polygon until it has two positions
+  // (and a 3rd which is just the first repeated)
+  if (geojson.geometry.coordinates.length === 0) return;
+
+  const coordinateCount = geojson.geometry.coordinates[0].length;
+  // 2 coordinates after selecting a draw type
+  // 3 after creating the first point
+  if (coordinateCount < 3) {
+    return;
+  }
+  geojson.properties.meta = Constants.meta.FEATURE;
+  display(
+    createVertex(
+      state.polygon.id,
+      geojson.geometry.coordinates[0][0],
+      "0.0",
+      false
+    )
+  );
+  if (coordinateCount > 3) {
+    // Add a start position marker to the map, clicking on this will finish the feature
+    // This should only be shown when we're in a valid spot
+    const endPos = geojson.geometry.coordinates[0].length - 3;
+    display(
+      createVertex(
+        state.polygon.id,
+        geojson.geometry.coordinates[0][endPos],
+        `0.${endPos}`,
+        false
+      )
+    );
+  }
+  if (coordinateCount <= 4) {
+    // If we've only drawn two positions (plus the closer),
+    // make a LineString instead of a Polygon
+    const lineCoordinates = [
+      [
+        geojson.geometry.coordinates[0][0][0],
+        geojson.geometry.coordinates[0][0][1]
+      ],
+      [
+        geojson.geometry.coordinates[0][1][0],
+        geojson.geometry.coordinates[0][1][1]
+      ]
+    ];
+    // create an initial vertex so that we can track the first point on mobile devices
+    display({
+      type: Constants.geojsonTypes.FEATURE,
+      properties: geojson.properties,
+      geometry: {
+        coordinates: lineCoordinates,
+        type: Constants.geojsonTypes.LINE_STRING
+      }
+    });
+    if (coordinateCount === 3) {
+      return;
+    }
+  }
+  // render the Polygon
+  return display(geojson);
+};
+
+DrawPolygon.onTrash = function(state) {
+  if (state.redraw) return;
+
+  this.deleteFeature([state.polygon.id], { silent: true });
+  this.changeMode(Constants.modes.SIMPLE_SELECT);
+};
+
+module.exports = DrawPolygon;

--- a/src/modes/draw_freehand_polygon.js
+++ b/src/modes/draw_freehand_polygon.js
@@ -8,13 +8,12 @@ const {
 const doubleClickZoom = require("../lib/double_click_zoom");
 const simplify = require("@turf/simplify").default;
 
-//const { onMouseMove, ...DrawFreehandPolygon } = Object.assign({}, DrawPolygon);
-const DrawFreehandPolygon = {};
+const { onMouseMove, ...DrawFreehandPolygon } = Object.assign({}, DrawPolygon);
 
 DrawFreehandPolygon.onSetup = function (opts = {}) {
   const polygon = this.newFeature({
     type: geojsonTypes.FEATURE,
-    properties: {},
+    properties: { freehand: true },
     geometry: {
       type: geojsonTypes.POLYGON,
       coordinates: [[]],
@@ -70,33 +69,16 @@ DrawFreehandPolygon.onDragEnd = DrawFreehandPolygon.onMouseUp = function (state,
       highQuality: true,
     });
 
-    if (state.polygon.isValid()) {
-      this.map.fire(events.CREATE, {
-        features: [state.polygon.toGeoJSON()]
-      });
-    }
-
     if (state.multiple) {
       this.changeMode(modes.DRAW_FREEHAND_POLYGON, { multiple: true });
     } else {
-      // this.fireUpdate();
       this.changeMode(modes.SIMPLE_SELECT, { featureIds: [state.polygon.id] });
-      this.clearSelectedFeatures();
     }
   }
 };
 
-DrawFreehandPolygon.toDisplayFeatures = DrawPolygon.toDisplayFeatures;
-
 DrawFreehandPolygon.onTouchEnd = function (state, e) {
   this.onMouseUp(state, e);
-};
-
-DrawFreehandPolygon.fireUpdate = function () {
-  this.map.fire(events.UPDATE, {
-    action: updateActions.MOVE,
-    features: this.getSelected().map((f) => f.toGeoJSON()),
-  });
 };
 
 module.exports = DrawFreehandPolygon;

--- a/src/modes/draw_polygon.js
+++ b/src/modes/draw_polygon.js
@@ -114,6 +114,8 @@ DrawPolygon.onMouseMove = function(state, e) {
 };
 
 DrawPolygon.onTap = DrawPolygon.onClick = function(state, e) {
+  if (state.polygon.properties.freehand) return;
+
   // delete previously drawn polygon if it exists
   if (state.redraw && state.previousFeatureId) {
     this.deleteFeature(state.previousFeatureId, { silent: true });
@@ -146,14 +148,7 @@ DrawPolygon.onStop = function(state) {
 
   //remove last added coordinate
   state.polygon.removeCoordinate(`0.${state.currentVertexPosition}`);
-  if (state.multiple && state.polygon.isValid()) {
-    const allFeatures = state.polygon.ctx.store._features;
-
-    this.map.fire(Constants.events.CREATE, {
-      features: Object.keys(allFeatures).map(featureId => allFeatures[featureId].toGeoJSON()),
-      newFeature: [state.polygon.toGeoJSON()]
-    });
-  } else if (state.polygon.isValid()) {
+  if (state.polygon.isValid()) {
     this.map.fire(Constants.events.CREATE, {
       features: [state.polygon.toGeoJSON()]
     });

--- a/src/modes/index.js
+++ b/src/modes/index.js
@@ -3,6 +3,7 @@ module.exports = {
   direct_select: require("./direct_select"),
   draw_point: require("./draw_point"),
   draw_polygon: require("./draw_polygon"),
+  draw_freehand_polygon: require("./draw_freehand_polygon"),
   draw_line_string: require("./draw_line_string"),
   split: require("./split"),
   coincident_select: require("./coincident_select"),


### PR DESCRIPTION
Adds a new mode called draw freehand polygon. Allows the user to draw a polygon using freehand mode.

I commented out the default mouse up event handling, since I do not believe we need it and it was the only way to get the mouse up event to register when drawing polygons.