### PR TITLE
Disable select

### DIFF
--- a/src/lib/is_selectable.js
+++ b/src/lib/is_selectable.js
@@ -1,0 +1,9 @@
+/**
+ * Determine if a selectable parameter was passed into a modes options
+ *
+ * @param {object} options
+ * @return {boolean} selectable
+ */
+module.exports = function(opts) {
+  return opts.hasOwnProperty('selectable') ? !!opts.selectable : true;
+}

--- a/src/modes/draw_freehand_polygon.js
+++ b/src/modes/draw_freehand_polygon.js
@@ -7,6 +7,7 @@ const {
 } = require("../constants");
 const doubleClickZoom = require("../lib/double_click_zoom");
 const calculateTolerance = require("../lib/calculate_tolerance");
+const isSelectable = require("../lib/is_selectable");
 const simplify = require("@turf/simplify").default;
 
 const { onMouseMove, ...DrawFreehandPolygon } = Object.assign({}, DrawPolygon);
@@ -16,9 +17,7 @@ DrawFreehandPolygon.onSetup = function (opts = {}) {
     type: geojsonTypes.FEATURE,
     properties: {
       freehand: true,
-      selectable: opts.hasOwnProperty('selectable')
-        ? !!opts.selectable
-        : true
+      selectable: isSelectable(opts)
     },
     geometry: {
       type: geojsonTypes.POLYGON,

--- a/src/modes/draw_freehand_polygon.js
+++ b/src/modes/draw_freehand_polygon.js
@@ -16,7 +16,9 @@ DrawFreehandPolygon.onSetup = function (opts = {}) {
     type: geojsonTypes.FEATURE,
     properties: {
       freehand: true,
-      selectable: !!opts.selectable
+      selectable: opts.hasOwnProperty('selectable')
+        ? !!opts.selectable
+        : true
     },
     geometry: {
       type: geojsonTypes.POLYGON,

--- a/src/modes/draw_freehand_polygon.js
+++ b/src/modes/draw_freehand_polygon.js
@@ -14,7 +14,10 @@ const { onMouseMove, ...DrawFreehandPolygon } = Object.assign({}, DrawPolygon);
 DrawFreehandPolygon.onSetup = function (opts = {}) {
   const polygon = this.newFeature({
     type: geojsonTypes.FEATURE,
-    properties: { freehand: true },
+    properties: {
+      freehand: true,
+      selectable: !!opts.selectable
+    },
     geometry: {
       type: geojsonTypes.POLYGON,
       coordinates: [[]],

--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -75,7 +75,7 @@ DrawLineString.onSetup = function (opts) {
   } else {
     line = this.newFeature({
       type: Constants.geojsonTypes.FEATURE,
-      properties: {},
+      properties: { selectable: !!opts.selectable },
       geometry: {
         type: Constants.geojsonTypes.LINE_STRING,
         coordinates: []

--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -75,7 +75,11 @@ DrawLineString.onSetup = function (opts) {
   } else {
     line = this.newFeature({
       type: Constants.geojsonTypes.FEATURE,
-      properties: { selectable: !!opts.selectable },
+      properties: {
+        selectable: opts.hasOwnProperty('selectable')
+          ? !!opts.selectable
+          : true
+      },
       geometry: {
         type: Constants.geojsonTypes.LINE_STRING,
         coordinates: []

--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -3,6 +3,7 @@ const isEventAtCoordinates = require("../lib/is_event_at_coordinates");
 const doubleClickZoom = require("../lib/double_click_zoom");
 const Constants = require("../constants");
 const createVertex = require("../lib/create_vertex");
+const isSelectable = require("../lib/is_selectable");
 const cursors = require("../constants").cursors;
 
 const DrawLineString = {};
@@ -75,11 +76,7 @@ DrawLineString.onSetup = function (opts) {
   } else {
     line = this.newFeature({
       type: Constants.geojsonTypes.FEATURE,
-      properties: {
-        selectable: opts.hasOwnProperty('selectable')
-          ? !!opts.selectable
-          : true
-      },
+      properties: { selectable: isSelectable(opts) },
       geometry: {
         type: Constants.geojsonTypes.LINE_STRING,
         coordinates: []

--- a/src/modes/draw_point.js
+++ b/src/modes/draw_point.js
@@ -1,4 +1,5 @@
 const CommonSelectors = require("../lib/common_selectors");
+const isSelectable = require("../lib/is_selectable");
 const Constants = require("../constants");
 const cursors = Constants.cursors;
 
@@ -19,11 +20,7 @@ DrawPoint.onSetup = function(opts = {}) {
 
   const point = this.newFeature({
     type: Constants.geojsonTypes.FEATURE,
-    properties: {
-      selectable: opts.hasOwnProperty('selectable')
-        ? !!opts.selectable
-        : true
-    },
+    properties: { selectable: isSelectable(opts) },
     geometry: {
       type: Constants.geojsonTypes.POINT,
       coordinates: []

--- a/src/modes/draw_point.js
+++ b/src/modes/draw_point.js
@@ -19,7 +19,7 @@ DrawPoint.onSetup = function(opts = {}) {
 
   const point = this.newFeature({
     type: Constants.geojsonTypes.FEATURE,
-    properties: {},
+    properties: { selectable: !!opts.selectable },
     geometry: {
       type: Constants.geojsonTypes.POINT,
       coordinates: []

--- a/src/modes/draw_point.js
+++ b/src/modes/draw_point.js
@@ -19,7 +19,11 @@ DrawPoint.onSetup = function(opts = {}) {
 
   const point = this.newFeature({
     type: Constants.geojsonTypes.FEATURE,
-    properties: { selectable: !!opts.selectable },
+    properties: {
+      selectable: opts.hasOwnProperty('selectable')
+        ? !!opts.selectable
+        : true
+    },
     geometry: {
       type: Constants.geojsonTypes.POINT,
       coordinates: []

--- a/src/modes/draw_polygon.js
+++ b/src/modes/draw_polygon.js
@@ -3,6 +3,7 @@ const doubleClickZoom = require("../lib/double_click_zoom");
 const Constants = require("../constants");
 const isEventAtCoordinates = require("../lib/is_event_at_coordinates");
 const createVertex = require("../lib/create_vertex");
+const isSelectable = require("../lib/is_selectable");
 const cursors = Constants.cursors;
 
 
@@ -23,11 +24,7 @@ DrawPolygon.onSetup = function(opts) {
 
   const polygon = this.newFeature({
     type: Constants.geojsonTypes.FEATURE,
-    properties: {
-      selectable: opts.hasOwnProperty('selectable')
-        ? !!opts.selectable
-        : true
-    },
+    properties: { selectable: isSelectable(opts) },
     geometry: {
       type: Constants.geojsonTypes.POLYGON,
       coordinates: [[]]

--- a/src/modes/draw_polygon.js
+++ b/src/modes/draw_polygon.js
@@ -23,7 +23,11 @@ DrawPolygon.onSetup = function(opts) {
 
   const polygon = this.newFeature({
     type: Constants.geojsonTypes.FEATURE,
-    properties: { selectable: !!opts.selectable },
+    properties: {
+      selectable: opts.hasOwnProperty('selectable')
+        ? !!opts.selectable
+        : true
+    },
     geometry: {
       type: Constants.geojsonTypes.POLYGON,
       coordinates: [[]]

--- a/src/modes/draw_polygon.js
+++ b/src/modes/draw_polygon.js
@@ -23,7 +23,7 @@ DrawPolygon.onSetup = function(opts) {
 
   const polygon = this.newFeature({
     type: Constants.geojsonTypes.FEATURE,
-    properties: {},
+    properties: { selectable: !!opts.selectable },
     geometry: {
       type: Constants.geojsonTypes.POLYGON,
       coordinates: [[]]

--- a/src/modes/freehand.js
+++ b/src/modes/freehand.js
@@ -24,13 +24,11 @@ const { onMouseMove, ...FreeDraw } = Object.assign({}, DrawPolygon);
 FreeDraw.onSetup = function () {
   const polygon = this.newFeature({
     type: geojsonTypes.FEATURE,
-    properties: {},
+    properties: { selectable: false },
     geometry: {
       type: geojsonTypes.POLYGON,
       coordinates: [[]],
     },
-    // The id of the freedrawn polygon is explicitly set, so we can tell simple_select's click handler
-    // not to do anything with this feature.
     id: "no_interact",
   });
 

--- a/src/modes/marquee.js
+++ b/src/modes/marquee.js
@@ -6,7 +6,7 @@ const { onMouseMove, ...RectangularDraw } = Object.assign({}, DrawPolygon);
 RectangularDraw.onSetup = function () {
   const polygon = this.newFeature({
     type: geojsonTypes.FEATURE,
-    properties: {},
+    properties: { selectable: false },
     geometry: {
       type: geojsonTypes.POLYGON,
       coordinates: [[]],

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -185,11 +185,11 @@ SimpleSelect.startOnActiveFeature = function (state, e) {
 };
 
 SimpleSelect.clickOnFeature = function (state, e) {
-  const eventFeature = e.featureTarget.properties;
-  const feature = this.getFeature(eventFeature.id);
+  const featureId = e.featureTarget.properties.id;
+  const feature = this.getFeature(featureId);
   // This prevents a polygon drawn in freehand or marquee mode from being resized/moved.
-  if (eventFeature.id === 'no_interact' ||
-    (feature.properties && feature.properties.hasOwnProperty('selectable') && !feature.properties.selectable)) {
+  // always have to check for the selectable property existence cause it could be added from the api
+  if (feature.properties && feature.properties.hasOwnProperty('selectable') && !feature.properties.selectable) {
     return;
   }
 
@@ -199,7 +199,6 @@ SimpleSelect.clickOnFeature = function (state, e) {
 
   const isShiftClick = CommonSelectors.isShiftDown(e);
   const selectedFeatureIds = this.getSelectedIds();
-  const featureId = e.featureTarget.properties.id;
   const isFeatureSelected = this.isSelected(featureId);
 
   // Click (without shift) on any selected feature but a point

--- a/src/modes/simple_select.js
+++ b/src/modes/simple_select.js
@@ -185,8 +185,13 @@ SimpleSelect.startOnActiveFeature = function (state, e) {
 };
 
 SimpleSelect.clickOnFeature = function (state, e) {
+  const eventFeature = e.featureTarget.properties;
+  const feature = this.getFeature(eventFeature.id);
   // This prevents a polygon drawn in freehand or marquee mode from being resized/moved.
-  if (e.featureTarget.properties.id === 'no_interact') return;
+  if (eventFeature.id === 'no_interact' ||
+    (feature.properties && feature.properties.hasOwnProperty('selectable') && !feature.properties.selectable)) {
+    return;
+  }
 
   // Stop everything
   doubleClickZoom.disable(this);


### PR DESCRIPTION
[https://www.pivotaltracker.com/story/show/175763444](https://www.pivotaltracker.com/story/show/175763444)

This disables selecting of a shape when the user is in simple select mode. It also allows you to create a shape that isn't selectable. You can still select a shape programatically using the direct select mode and the shapes id.