### PR TITLE
export modes

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,4 +28,4 @@ module.exports = function(options) {
   setupDraw(options, this);
 };
 
-module.exports.modes = require("./src/modes");
+module.exports.modes = Constants.modes;

--- a/index.js
+++ b/index.js
@@ -28,4 +28,5 @@ module.exports = function(options) {
   setupDraw(options, this);
 };
 
-module.exports.modes = Constants.modes;
+module.exports.modes = require("./src/modes");
+module.exports.modeNames = Constants.modes;


### PR DESCRIPTION
Export the names of the draw modes. We aren't using the currently exported modes in vetro so I replaced it with the constants. I see no reason you would ever manipulate the mode directly.