### PR TITLE
Highlight width

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -226,5 +226,16 @@ module.exports = function(ctx, api) {
     ctx.store.setFeatureProperty(featureId, property, value);
     return api;
   };
+
+  api.updateLinePaintProperty = function({ propertyName, value } = {}) {
+    const layerIds = Object.values(Constants.layerIds.LINE)
+      .map(id => ([`${id}.hot`, `${id}.cold`]))
+      .flat();
+
+    layerIds.forEach(id => {
+      ctx.map.setPaintProperty(id, propertyName, value);
+    });
+  };
+
   return api;
 };

--- a/src/api.js
+++ b/src/api.js
@@ -227,13 +227,23 @@ module.exports = function(ctx, api) {
     return api;
   };
 
-  api.updateLinePaintProperty = function({ propertyName, value } = {}) {
+  api.updateLineWidthProperty = function(value) {
     const layerIds = Object.values(Constants.layerIds.LINE)
       .map(id => ([`${id}.hot`, `${id}.cold`]))
       .flat();
 
     layerIds.forEach(id => {
-      ctx.map.setPaintProperty(id, propertyName, value);
+      ctx.map.setPaintProperty(id, 'line-width', value);
+    });
+  };
+
+  api.resetLineWidthProperty = function() {
+    const layerIds = Object.values(Constants.layerIds.LINE)
+      .map(id => ([`${id}.hot`, `${id}.cold`]))
+      .flat();
+
+    layerIds.forEach(id => {
+      ctx.map.setPaintProperty(id, 'line-width', Constants.paintProperties.LINE.WIDTH);
     });
   };
 

--- a/src/api.js
+++ b/src/api.js
@@ -6,6 +6,7 @@ const stringSetsAreEqual = require("./lib/string_sets_are_equal");
 const geojsonhint = require("@mapbox/geojsonhint");
 const Constants = require("./constants");
 const StringSet = require("./lib/string_set");
+const { linePaintProperties } = require('./utils');
 
 const featureTypes = {
   Polygon: require("./feature_types/polygon"),
@@ -228,23 +229,11 @@ module.exports = function(ctx, api) {
   };
 
   api.updateLineWidthProperty = function(value) {
-    const layerIds = Object.values(Constants.layerIds.LINE)
-      .map(id => ([`${id}.hot`, `${id}.cold`]))
-      .flat();
-
-    layerIds.forEach(id => {
-      ctx.map.setPaintProperty(id, 'line-width', value);
-    });
+    linePaintProperties.updateLineWidth(ctx, value);
   };
 
   api.resetLineWidthProperty = function() {
-    const layerIds = Object.values(Constants.layerIds.LINE)
-      .map(id => ([`${id}.hot`, `${id}.cold`]))
-      .flat();
-
-    layerIds.forEach(id => {
-      ctx.map.setPaintProperty(id, 'line-width', Constants.paintProperties.LINE.WIDTH);
-    });
+    linePaintProperties.updateLineWidth(ctx, Constants.paintProperties.LINE.WIDTH);
   };
 
   return api;

--- a/src/constants.js
+++ b/src/constants.js
@@ -103,4 +103,11 @@ module.exports = {
       STATIC: 'gl-draw-line-static',
     },
   },
+  paintProperties: {
+    LINE: {
+      WIDTH: 5,
+      COLOR: '#FFD300',
+      OPACITY: 0.7,
+    },
+  },
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -96,4 +96,11 @@ module.exports = {
   LAT_RENDERED_MAX: 85,
   LNG_MIN: -270,
   LNG_MAX: 270,
+  layerIds: {
+    LINE: {
+      INACTIVE: 'gl-draw-line-inactive',
+      ACTIVE: 'gl-draw-line-active',
+      STATIC: 'gl-draw-line-static',
+    },
+  },
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -100,7 +100,6 @@ module.exports = {
     LINE: {
       INACTIVE: 'gl-draw-line-inactive',
       ACTIVE: 'gl-draw-line-active',
-      STATIC: 'gl-draw-line-static',
     },
   },
   paintProperties: {

--- a/src/events.js
+++ b/src/events.js
@@ -167,8 +167,7 @@ module.exports = function (ctx) {
 
   // 8 - Backspace
   // 46 - Delete
-  const isKeyModeValid = (code) =>
-    !(code === 8 || code === 46 || (code >= 48 && code <= 57));
+  const isKeyModeValid = (code) => !(code === 8 || code === 46);
 
   events.keydown = function (event) {
     if ((event.srcElement || event.target).classList[0] !== "mapboxgl-canvas")

--- a/src/events.js
+++ b/src/events.js
@@ -180,14 +180,6 @@ module.exports = function (ctx) {
     ) {
       event.preventDefault();
       currentMode.trash();
-    } else if (isKeyModeValid(event.keyCode)) {
-      currentMode.keydown(event);
-    } else if (event.keyCode === 49 && ctx.options.controls.point) {
-      changeMode(Constants.modes.DRAW_POINT);
-    } else if (event.keyCode === 50 && ctx.options.controls.line_string) {
-      changeMode(Constants.modes.DRAW_LINE_STRING);
-    } else if (event.keyCode === 51 && ctx.options.controls.polygon) {
-      changeMode(Constants.modes.DRAW_POLYGON);
     }
   };
 

--- a/src/lib/theme.js
+++ b/src/lib/theme.js
@@ -1,3 +1,5 @@
+const Constants = require('../constants');
+
 module.exports = [
   {
     'id': 'gl-draw-polygon-fill-inactive',
@@ -56,7 +58,7 @@ module.exports = [
     }
   },
   {
-    'id': 'gl-draw-line-inactive',
+    'id': Constants.layerIds.LINE.INACTIVE,
     'type': 'line',
     'filter': ['all',
       ['==', 'active', 'false'],
@@ -74,7 +76,7 @@ module.exports = [
     }
   },
   {
-    'id': 'gl-draw-line-active',
+    'id': Constants.layerIds.LINE.ACTIVE,
     'type': 'line',
     'filter': ['all',
       ['==', '$type', 'LineString'],
@@ -197,7 +199,7 @@ module.exports = [
     }
   },
   {
-    'id': 'gl-draw-line-static',
+    'id': Constants.layerIds.LINE.STATIC,
     'type': 'line',
     'filter': ['all', ['==', 'mode', 'static'], ['==', '$type', 'LineString']],
     'layout': {

--- a/src/lib/theme.js
+++ b/src/lib/theme.js
@@ -70,9 +70,9 @@ module.exports = [
       'line-join': 'round'
     },
     'paint': {
-      'line-color': '#FFD300',
-      'line-width': 5,
-      'line-opacity': 0.7
+      'line-color': Constants.paintProperties.LINE.COLOR,
+      'line-width': Constants.paintProperties.LINE.WIDTH,
+      'line-opacity': Constants.paintProperties.LINE.OPACITY,
     }
   },
   {
@@ -87,9 +87,9 @@ module.exports = [
       'line-join': 'round'
     },
     'paint': {
-      'line-color': '#FFD300',
-      'line-width': 5,
-      'line-opacity': 0.7
+      'line-color': Constants.paintProperties.LINE.COLOR,
+      'line-width': Constants.paintProperties.LINE.WIDTH,
+      'line-opacity': Constants.paintProperties.LINE.OPACITY,
     }
   },
   {
@@ -199,7 +199,7 @@ module.exports = [
     }
   },
   {
-    'id': Constants.layerIds.LINE.STATIC,
+    'id': 'gl-draw-line-static',
     'type': 'line',
     'filter': ['all', ['==', 'mode', 'static'], ['==', '$type', 'LineString']],
     'layout': {
@@ -209,7 +209,7 @@ module.exports = [
     'paint': {
       'line-color': '#404040',
       'line-width': 5,
-      'line-opacity': 0
+      'line-opacity': 0,
     }
   },
   {

--- a/src/modes/draw_line_string.js
+++ b/src/modes/draw_line_string.js
@@ -95,11 +95,12 @@ DrawLineString.onSetup = function (opts) {
   });
 
   return {
-    line,
     currentVertexPosition,
     direction,
+    ignoreDeleteKey: opts.ignoreDeleteKey,
+    line,
+    previousFeatureId: opts.previousFeatureId,
     redraw: opts.redraw,
-    previousFeatureId: opts.previousFeatureId
   };
 };
 
@@ -182,19 +183,6 @@ DrawLineString.onTap = DrawLineString.onClick = function (state, e) {
   this.clickAnywhere(state, e);
 };
 
-DrawLineString.onKeyUp = function (state, e) {
-  if (state.redraw) return;
-
-  if (CommonSelectors.isEnterKey(e)) {
-    this.changeMode(Constants.modes.SIMPLE_SELECT, {
-      featureIds: [state.line.id]
-    });
-  } else if (CommonSelectors.isEscapeKey(e)) {
-    this.deleteFeature([state.line.id], { silent: true });
-    this.changeMode(Constants.modes.SIMPLE_SELECT);
-  }
-};
-
 DrawLineString.onStop = function (state) {
   doubleClickZoom.enable(this);
   this.activateUIButton();
@@ -215,7 +203,7 @@ DrawLineString.onStop = function (state) {
 };
 
 DrawLineString.onTrash = function (state) {
-  if (state.redraw) return;
+  if (state.redraw || state.ignoreDeleteKey) return;
 
   this.deleteFeature([state.line.id], { silent: true });
   this.changeMode(Constants.modes.SIMPLE_SELECT);

--- a/src/modes/draw_point.js
+++ b/src/modes/draw_point.js
@@ -100,12 +100,4 @@ DrawPoint.toDisplayFeatures = function(state, geojson, display) {
 
 DrawPoint.onTrash = DrawPoint.stopDrawingAndRemove;
 
-DrawPoint.onKeyUp = function(state, e) {
-  if (state.redraw) return;
-
-  if (CommonSelectors.isEscapeKey(e) || CommonSelectors.isEnterKey(e)) {
-    return this.stopDrawingAndRemove(state, e);
-  }
-};
-
 module.exports = DrawPoint;

--- a/src/modes/draw_polygon.js
+++ b/src/modes/draw_polygon.js
@@ -44,9 +44,10 @@ DrawPolygon.onSetup = function(opts) {
   return {
     polygon,
     currentVertexPosition: 0,
-    redraw: opts.redraw,
-    previousFeatureId: opts.previousFeatureId,
+    ignoreDeleteKey: opts.ignoreDeleteKey,
     multiple: opts.multiple,
+    previousFeatureId: opts.previousFeatureId,
+    redraw: opts.redraw,
   };
 };
 
@@ -124,19 +125,6 @@ DrawPolygon.onTap = DrawPolygon.onClick = function(state, e) {
 
   if (CommonSelectors.isVertex(e)) return this.clickOnVertex(state, e);
   return this.clickAnywhere(state, e);
-};
-
-DrawPolygon.onKeyUp = function(state, e) {
-  if (state.redraw) return;
-
-  if (CommonSelectors.isEscapeKey(e)) {
-    this.deleteFeature([state.polygon.id], { silent: true });
-    this.changeMode(Constants.modes.SIMPLE_SELECT);
-  } else if (CommonSelectors.isEnterKey(e)) {
-    this.changeMode(Constants.modes.SIMPLE_SELECT, {
-      featureIds: [state.polygon.id]
-    });
-  }
 };
 
 DrawPolygon.onStop = function(state) {
@@ -229,7 +217,7 @@ DrawPolygon.toDisplayFeatures = function(state, geojson, display) {
 };
 
 DrawPolygon.onTrash = function(state) {
-  if (state.redraw) return;
+  if (state.redraw || state.ignoreDeleteKey) return;
 
   this.deleteFeature([state.polygon.id], { silent: true });
   this.changeMode(Constants.modes.SIMPLE_SELECT);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,5 @@
+const linePaintProperties = require('./linePaintProperties');
+
+module.exports = {
+  linePaintProperties
+};

--- a/src/utils/linePaintProperties.js
+++ b/src/utils/linePaintProperties.js
@@ -1,0 +1,13 @@
+const Constants = require("../constants");
+
+module.exports = {
+  updateLineWidth(ctx, value) {
+    const layerIds = Object.values(Constants.layerIds.LINE)
+      .map(id => ([`${id}.hot`, `${id}.cold`]))
+      .flat();
+
+    layerIds.forEach(id => {
+      ctx.map.setPaintProperty(id, 'line-width', value);
+    });
+  }
+};


### PR DESCRIPTION
[https://www.pivotaltracker.com/story/show/175355839](https://www.pivotaltracker.com/story/show/175355839)

This is just targeted at fixing the current bug ticket. We could expand this to add more paint properties as needed. Currently, the mapbox gl draw plugin is using a mix of layers depending on what the user is doing and only certain paint properties for points, lines, and polygons.