### PR TITLE
Use Source Geometry Fetch For Coincident Cables

### DIFF
--- a/src/modes/coincident_select.js
+++ b/src/modes/coincident_select.js
@@ -94,8 +94,8 @@ CoincidentSelect.onSetup = async function(opts) {
       if(typeof this._ctx.options.fetchSourceGeometry === "function"){
 
         const [ lineSrcGeom, ptSrcGeom ] = await Promise.all([
-          this._ctx.options.fetchSourceGeometry(f),
-          this._ctx.options.fetchSourceGeometry({ properties: { vetro_id: state.initiallySelectedFeatureIds[0] }})
+          this._ctx.options.fetchSourceGeometry(f.properties.vetro_id),
+          this._ctx.options.fetchSourceGeometry(state.initiallySelectedFeatureIds[0])
         ]);
 
         if(lineSrcGeom && lineSrcGeom.type && lineSrcGeom.coordinates.length){

--- a/src/modes/coincident_select.js
+++ b/src/modes/coincident_select.js
@@ -93,7 +93,7 @@ CoincidentSelect.onSetup = async function(opts) {
       let lineGeom = f.geometry;
       if(typeof this._ctx.options.fetchSourceGeometry === "function"){
 
-        const [ lineSrcGeom, ptSrcGeom ] = await Promise.allSettled([
+        const [ lineSrcGeom, ptSrcGeom ] = await Promise.all([
           this._ctx.options.fetchSourceGeometry(f),
           this._ctx.options.fetchSourceGeometry({ properties: { vetro_id: state.initiallySelectedFeatureIds[0] }})
         ]);

--- a/src/modes/coincident_select.js
+++ b/src/modes/coincident_select.js
@@ -91,13 +91,17 @@ CoincidentSelect.onSetup = async function(opts) {
     ) {
 
       let lineGeom = f.geometry;
-      if(this._ctx.options.fetchSourceGeometry && typeof this._ctx.options.fetchSourceGeometry === "function"){
-        const lineSrcGeom = await this._ctx.options.fetchSourceGeometry(f);
+      if(typeof this._ctx.options.fetchSourceGeometry === "function"){
+
+        const [ lineSrcGeom, ptSrcGeom ] = await Promise.allSettled([
+          this._ctx.options.fetchSourceGeometry(f),
+          this._ctx.options.fetchSourceGeometry({ properties: { vetro_id: state.initiallySelectedFeatureIds[0] }})
+        ]);
+
         if(lineSrcGeom && lineSrcGeom.type && lineSrcGeom.coordinates.length){
           lineGeom = lineSrcGeom;
         }
 
-        const ptSrcGeom = await this._ctx.options.fetchSourceGeometry({ properties: { vetro_id: state.initiallySelectedFeatureIds[0] }});
         if(ptSrcGeom && ptSrcGeom.type && ptSrcGeom.coordinates.length){
           feature = ptSrcGeom;
         }

--- a/src/modes/object_to_mode.js
+++ b/src/modes/object_to_mode.js
@@ -33,8 +33,8 @@ module.exports = function(modeObject) {
     }
 
     return {
-      start() {
-        state = mode.onSetup(startOpts); // this should set ui buttons
+      async start() {
+        state = await mode.onSetup(startOpts); // this should set ui buttons
 
         // Adds event handlers for all event options
         // add sets the selector to false for all


### PR DESCRIPTION
Switches from the geojson_string to using the fetch function to get source geometry for coincidence checking.