### PR TITLE
fix a snapping issue in split mode

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -53,6 +53,7 @@ module.exports = {
     STATIC: "static",
     FREEHAND: "freehand",
     MARQUEE: "marquee",
+    SPLIT: "split",
   },
   groupSelectModes: ["freehand", "marquee"],
   events: {

--- a/src/snapping/index.js
+++ b/src/snapping/index.js
@@ -164,7 +164,7 @@ class Snapping {
         layers: bufferLayerIds,
       })
       .find(featureFilter);
-
+    
     if (!snapToFeature) {
       this._mouseoutHandler();
       return;

--- a/src/snapping/util.js
+++ b/src/snapping/util.js
@@ -1,6 +1,6 @@
 const turfDistance = require("@turf/distance").default;
 
-const { DRAW_POINT } = require("../constants").modes;
+const { DRAW_POINT, SPLIT } = require("../constants").modes;
 
 const LINE_TYPES = ["line", "fill", "fill-extrusion"];
 const CIRCLE_TYPES = ["circle", "symbol"];
@@ -93,6 +93,7 @@ const notSelfOrCurrentSnapFilter = (vetroId, snappedVetroId) => (feature) =>
 
 exports.getFeatureFilter = (selectedFeature, snappedFeature, mode) => {
   if (mode === DRAW_POINT) return notPointFilter;
+  if (mode === SPLIT) return () => true;
   if (!selectedFeature) return () => true;
 
   const { geometry, id: vetroId } = selectedFeature;
@@ -102,7 +103,6 @@ exports.getFeatureFilter = (selectedFeature, snappedFeature, mode) => {
 
   const { properties } = snappedFeature || {};
   const { vetro_id: snappedVetroId } = properties || {};
-
 
   return notSelfOrCurrentSnapFilter(vetroId, snappedVetroId);
 };


### PR DESCRIPTION
pivotal [#178134860](https://www.pivotaltracker.com/story/show/178134860)

fix the issue that 
1. Snap symbol does not show.
2. Clicking does not place a splitting point.

if we follow the steps:
1. in editing mode
2. Select cable
3. Select Split tool
4. Move pointer over selected cable