### PR TITLE
179526515 snap to vertex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1263,6 +1263,22 @@
         }
       }
     },
+    "@turf/circle": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-6.5.0.tgz",
+      "integrity": "sha512-oU1+Kq9DgRnoSbWFHKnnUdTmtcRUMmHoV9DjTXu9vOLNV5OWtAAh1VZ+mzsioGGzoDNT/V5igbFOkMfBQc0B6A==",
+      "requires": {
+        "@turf/destination": "^6.5.0",
+        "@turf/helpers": "^6.5.0"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+          "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
+        }
+      }
+    },
     "@turf/clean-coords": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
@@ -1276,6 +1292,14 @@
           "version": "5.1.5",
           "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
           "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+        },
+        "@turf/invariant": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
+          "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
+          "requires": {
+            "@turf/helpers": "^5.1.5"
+          }
         }
       }
     },
@@ -1291,6 +1315,22 @@
           "version": "5.1.5",
           "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
           "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+        }
+      }
+    },
+    "@turf/destination": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-6.5.0.tgz",
+      "integrity": "sha512-4cnWQlNC8d1tItOz9B4pmJdWpXqS0vEvv65bI/Pj/genJnsL7evI0/Xw42RvEGROS481MPiU80xzvwxEvhQiMQ==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "dependencies": {
+        "@turf/helpers": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+          "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
         }
       }
     },
@@ -1324,17 +1364,17 @@
       "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
     },
     "@turf/invariant": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
-      "integrity": "sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
       "requires": {
-        "@turf/helpers": "^5.1.5"
+        "@turf/helpers": "^6.5.0"
       },
       "dependencies": {
         "@turf/helpers": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
-          "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+          "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
         }
       }
     },
@@ -4983,6 +5023,11 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -4993,6 +5038,11 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.last": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
+      "integrity": "sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw="
     },
     "lodash.memoize": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -78,13 +78,17 @@
     "@mapbox/geojson-normalize": "0.0.1",
     "@mapbox/geojsonhint": "3.0.0",
     "@mapbox/point-geometry": "0.1.0",
+    "@turf/circle": "^6.5.0",
     "@turf/distance": "^6.0.1",
     "@turf/helpers": "^6.3.0",
+    "@turf/invariant": "^6.5.0",
     "@turf/nearest-point-on-line": "^6.0.2",
     "@turf/simplify": "^5.1.5",
     "@turf/unkink-polygon": "^6.3.0",
     "hat": "0.0.3",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "^4.2.0",
+    "lodash.last": "^3.0.0",
     "lodash.throttle": "^4.1.1",
     "xtend": "^4.0.1"
   }

--- a/src/api.js
+++ b/src/api.js
@@ -3,7 +3,6 @@ const normalize = require("@mapbox/geojson-normalize");
 const hat = require("hat");
 const featuresAt = require("./lib/features_at");
 const stringSetsAreEqual = require("./lib/string_sets_are_equal");
-const geojsonhint = require("@mapbox/geojsonhint");
 const Constants = require("./constants");
 const StringSet = require("./lib/string_set");
 const { linePaintProperties } = require('./utils');
@@ -75,13 +74,7 @@ module.exports = function(ctx, api) {
     return newIds;
   };
 
-  api.add = function(geojson) {
-    const errors = geojsonhint
-      .hint(geojson, { precisionWarning: false })
-      .filter(e => e.level !== "message");
-    if (errors.length) {
-      throw new Error(errors[0].message);
-    }
+  api.add = function (geojson) {
     const featureCollection = JSON.parse(JSON.stringify(normalize(geojson)));
 
     const ids = featureCollection.features.map(feature => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -44,6 +44,7 @@ module.exports = {
     MULTI_POLYGON: "MultiPolygon",
   },
   modes: {
+    COINCIDENT_SELECT: "coincident_select",
     DRAW_LINE_STRING: "draw_line_string",
     DRAW_POLYGON: "draw_polygon",
     DRAW_FREEHAND_POLYGON: "draw_freehand_polygon",
@@ -99,14 +100,14 @@ module.exports = {
   LNG_MAX: 270,
   layerIds: {
     LINE: {
-      INACTIVE: 'gl-draw-line-inactive',
-      ACTIVE: 'gl-draw-line-active',
+      INACTIVE: "gl-draw-line-inactive",
+      ACTIVE: "gl-draw-line-active",
     },
   },
   paintProperties: {
     LINE: {
       WIDTH: 5,
-      COLOR: '#FFD300',
+      COLOR: "#FFD300",
       OPACITY: 0.7,
     },
   },

--- a/src/events.js
+++ b/src/events.js
@@ -1,5 +1,3 @@
-const throttle = require("lodash.throttle");
-
 const setupModeHandler = require("./lib/mode_handler");
 const CursorManager = require("./lib/cursor");
 const featuresAt = require("./lib/features_at");
@@ -267,12 +265,12 @@ module.exports = function (ctx) {
       }
     },
     addEventListeners() {
-      ctx.map.on("mousemove", throttle(events.mousemove, 40));
+      ctx.map.on("mousemove", events.mousemove);
       ctx.map.on("mousedown", events.mousedown);
       ctx.map.on("mouseup", events.mouseup);
       ctx.map.on("data", events.data);
 
-      ctx.map.on("touchmove", throttle(events.touchmove), 40);
+      ctx.map.on("touchmove", events.touchmove);
       ctx.map.on("touchstart", events.touchstart);
       ctx.map.on("touchend", events.touchend);
 

--- a/src/snapping/index.js
+++ b/src/snapping/index.js
@@ -42,7 +42,7 @@ const MOUSE_UP_MODES = [
 
 const MOUSE_DOWN_MODES = [DRAW_LINE_STRING, DRAW_POLYGON];
 
-const MOUSEMOVE_THROTTLE_MS = 16;
+const MOUSEMOVE_THROTTLE_MS = 100;
 
 class Snapping {
   constructor(ctx) {
@@ -255,7 +255,8 @@ class Snapping {
   }
 
   _circleFromMousePoint(x, y) {
-    const mouseLatLng = turfPoint(this.map.unproject([x, y]).toArray());
+    const mousePointAsLngLat = this.map.unproject([x, y]).toArray();
+    const mouseLatLng = turfPoint(mousePointAsLngLat);
 
     const snapDistanceDeltaLatLng = turfPoint(
       this.map.unproject([x + this.snapDistance, y]).toArray()
@@ -263,12 +264,12 @@ class Snapping {
 
     const km = turfDistance(mouseLatLng, snapDistanceDeltaLatLng);
 
-    const circle = turfCircle(this.map.unproject([x, y]).toArray(), km);
+    const circle = turfCircle(mousePointAsLngLat, km);
 
     return circle;
   }
 
-  _getClosestPoint(x, y) {
+  _getClosestMapboxPoint(x, y) {
     // get point buffers
     const pointBufferIds = this.bufferLayers
       .filter((id) => id.endsWith("point"))
@@ -383,7 +384,7 @@ class Snapping {
 
     // avoid snapping points to points
     if (this._isLineDraw()) {
-      snapToFeature = this._getClosestPoint(x, y);
+      snapToFeature = this._getClosestMapboxPoint(x, y);
     }
 
     if (!snapToFeature) {

--- a/src/snapping/index.js
+++ b/src/snapping/index.js
@@ -229,9 +229,7 @@ class Snapping {
     if (this._isSnappedToPoint()) return;
 
     // get edited coordinate
-    const updatedCoord = getCoord(
-      this.store.ctx.api.getSelectedPoints().features[0]
-    );
+    const updatedCoord = this._getUpdatedLineStringCoord();
 
     const [lng, lat] = updatedCoord;
 
@@ -241,7 +239,7 @@ class Snapping {
     const closestPoint = await this.getClosestPoint(vetroId, lng, lat);
 
     // find index of coord to update
-    const feature = cloneDeep(this.store.ctx.api.getSelected().features[0]);
+    const feature = cloneDeep(this.store.ctx.api.getAll().features[0]);
     const index = getCoords(feature).findIndex(
       (coord) => coord[0] === updatedCoord[0] && coord[1] === updatedCoord[1]
     );
@@ -252,6 +250,18 @@ class Snapping {
     // set this feature as the drawing
     const fc = turfFeatureCollection([feature]);
     this.store.ctx.api.set(fc);
+  }
+
+  _getUpdatedLineStringCoord() {
+    if (!this._isLineDraw()) {
+      throw new Error("Cannot get linstring coord for non-line draw");
+    }
+
+    if (this.store.ctx.api.getMode() === "direct_select") {
+      return getCoord(this.store.ctx.api.getSelectedPoints().features[0]);
+    } else {
+      return last(getCoords(this.store.ctx.api.getAll().features[0]));
+    }
   }
 
   _circleFromMousePoint(x, y) {


### PR DESCRIPTION
[#179526514](https://www.pivotaltracker.com/story/show/179526514)
[#179526515](https://www.pivotaltracker.com/story/show/179526515)

FE PR: https://github.com/NBTSolutions/vetro-2-front-end/pull/1428

**LOAD DIFF FOR src/snapping/index.js**

Snapping updates:
* Points are preferred to lines (when snapping a non-point)
* Vertices of lines are preferred to edges
* On mousemove, use turf/nearest-point-on-line for all lines
  * Do closest point calc in DB when a new vertex is "placed"
* Mousemove throttle:
  * removed for "native" draw handler
  * reduced to 16 ms for "snap" draw handler 
