### PR TITLE
do tolerance better

### DIFF
--- a/src/lib/calculate_tolerance.js
+++ b/src/lib/calculate_tolerance.js
@@ -4,6 +4,6 @@
  * @param {number} zoom
  * @return {number} tolerance
  */
-module.exports = function(zoom) {
-  return Math.abs(3 / (zoom * 150) - 0.000908); // https://www.desmos.com/calculator/h8z4rzoggh
+ module.exports = function (zoom) {
+  return Math.pow(2, -zoom) - Math.pow(2, -22);
 };

--- a/src/lib/calculate_tolerance.js
+++ b/src/lib/calculate_tolerance.js
@@ -4,6 +4,6 @@
  * @param {number} zoom
  * @return {number} tolerance
  */
-module.exports = function (zoom) {
+module.exports = function(zoom) {
   return Math.pow(2, -zoom) - Math.pow(2, -22);
 };

--- a/src/lib/calculate_tolerance.js
+++ b/src/lib/calculate_tolerance.js
@@ -5,5 +5,5 @@
  * @return {number} tolerance
  */
  module.exports = function (zoom) {
-  return Math.pow(2, -zoom) - Math.pow(2, -22);
+  return Math.pow(2, -zoom)
 };

--- a/src/lib/calculate_tolerance.js
+++ b/src/lib/calculate_tolerance.js
@@ -4,6 +4,6 @@
  * @param {number} zoom
  * @return {number} tolerance
  */
- module.exports = function (zoom) {
+module.exports = function (zoom) {
   return Math.pow(2, -zoom) - Math.pow(2, -22);
 };


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180635775

This was entertaining. The formula as it existed seems like it was a bit of a crude heuristic. 
The logic presumably was something like:
```
f(zoom) should start around .03 for small zoom and then tend towards 0 at large zooms. 
It should also descend more steeply initially.
```

That is all fine but is too adhoc. 
The formula as it existed varied inversely proportional to zoom. (like 1/zoom).
However the relationship that that needed to follow is the relationship between the zoom level and span of the visible map.
[That relationship is ~= 2^-zoom. ](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Resolution_and_Scale)

The behavior we were seeing was that the simplifications were too aggresive at higher zooms. ie. tolerance too high.
Which makes sense because 1/zoom doesnt descend  as fast as 2^-zoom.
