### PR TITLE
Fix annoying sentry error

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -128,7 +128,7 @@ module.exports = function (ctx, api) {
 
   api.getAll = function () {
     const features =
-      ctx.store.getAll().map((feature) => feature.toGeoJSON()) ?? [];
+      ctx?.store?.getAll().map((feature) => feature.toGeoJSON()) ?? [];
     return {
       type: Constants.geojsonTypes.FEATURE_COLLECTION,
       features,


### PR DESCRIPTION
[https://vetrofibermap.atlassian.net/jira/software/c/projects/PUF/boards/11?modal=detail&selectedIssue=PUF-356](https://github.com/stevage/mapbox-gl-draw/pull/url)

The culprit was a line in mapbox-gl-draw. There's an error where ctx.store is null, so an error is thrown before ?? can be evaluated. This one line was more than half of our sentry errors last month