### PR TITLE
raise peer dependency limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "unassertify": "^2.0.3"
   },
   "peerDependencies": {
-    "mapbox-gl": ">=0.27.0 <3.0.0"
+    "mapbox-gl": ">=0.27.0 <4.0.0"
   },
   "dependencies": {
     "@mapbox/geojson-area": "^0.2.1",


### PR DESCRIPTION
We use 3.16.0 in the front end, so I think this needs to increase