### PR TITLE
VETRO-18508 Split line mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mapbox-gl-draw",
-  "version": "1.2.31",
+  "version": "1.2.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mapbox-gl-draw",
-      "version": "1.2.31",
+      "version": "1.2.35",
       "license": "ISC",
       "dependencies": {
         "@mapbox/geojson-area": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-draw",
-  "version": "1.2.34",
+  "version": "1.2.35",
   "description": "A drawing component for Mapbox GL JS",
   "homepage": "https://github.com/mapbox/mapbox-gl-draw",
   "author": "mapbox",
@@ -24,7 +24,7 @@
     "build-token": "node build/generate-access-token-script.js",
     "build": "NODE_ENV=production browserify index.js --standalone MapboxDraw > dist/mapbox-gl-draw-unminified.js",
     "build-min": "NODE_ENV=production browserify index.js --standalone MapboxDraw | uglifyjs -c -m > dist/mapbox-gl-draw.js",
-    "prepublish": "npm run build && npm run build-min",
+    "prepublishOnly": "npm run build && npm run build-min",
     "start": "npm run build-token && node server.js"
   },
   "repository": {

--- a/src/modes/split.js
+++ b/src/modes/split.js
@@ -36,21 +36,25 @@ const clearData = map => {
   map.fire("draw.splitPoints", { splitPointGeometry: null });
 };
 
-SplitLine.onSetup = function onSetup({ featureFilter }) {
+SplitLine.onSetup = function onSetup({ featureFilter, featureId } = {}) {
+  // Select the target feature in the draw store so snapping can restrict to it.
+  // Without this, getSelectedIds() is empty and snapToSelectedLineForSplitEvent bails out.
+  if (featureId != null && this._ctx.store.get(featureId)) {
+    this._ctx.store.setSelected(featureId);
+  }
   this._ctx.snapping.setSnapToSelected(true);
   clearData(this.map);
   const removeSplitVertecies = () => {
     clearData(this.map);
   };
 
-  this._ctx.setGetCursorTypeLogic(({ snapped, overFeatures }) => {
+  // Do not use overFeatures here: it includes any map line under the cursor, which misleads
+  // users into thinking other lines are splittable. Only the snap ring indicates a valid mark.
+  this._ctx.setGetCursorTypeLogic(({ snapped }) => {
     if (snapped) {
       return cursors.ADD;
-    } else if (overFeatures) {
-      return cursors.POINTER;
-    } else {
-      return cursors.GRAB;
     }
+    return cursors.GRAB;
   });
 
   this._ctx.api.removeSplitVertecies = removeSplitVertecies;
@@ -94,25 +98,20 @@ SplitLine.onSetup = function onSetup({ featureFilter }) {
 
   this.setActionableState({});
 
-  return { featureFilter }; // this state will be passed to future events
+  return { featureFilter, featureId }; // this state will be passed to future events
 };
 
 SplitLine.onClick = function onClick(state, e) {
-  const lngLat = this._ctx.snapping.snapCoord(e, state.featureFilter);
-  if (!lngLat.snapped) {
-    // don't fire if we weren't close enough to a feature to snap to it.
+  const lngLat = this._ctx.api.snapToSelectedLineForSplitEvent(e);
+  if (!lngLat || !lngLat.snapped) {
     return;
   }
-  const { lat, lng, snappedFeature } = lngLat;
-  if (snappedFeature.geometry.type !== "LineString") {
-    return;
-  }
+  const { lat, lng } = lngLat;
   appendData(this.map, [lng, lat]);
 };
 
-SplitLine.onMouseMove = function onMouseMove(state, e) {
-  this._ctx.snapping.snapCoord(e, state.featureFilter);
-};
+// Snapping._mouseMoveHandler handles split snap on map mousemove (see SPLIT branch).
+SplitLine.onMouseMove = function onMouseMove() {};
 
 SplitLine.onTap = SplitLine.onClick;
 

--- a/src/snapping/index.js
+++ b/src/snapping/index.js
@@ -25,6 +25,7 @@ const {
   DRAW_POLYGON,
   COINCIDENT_SELECT,
   DRAW_POINT,
+  SPLIT,
 } = require("../constants").modes;
 
 const LINE_MODES = [DIRECT_SELECT, DRAW_LINE_STRING, DRAW_POLYGON];
@@ -117,6 +118,117 @@ class Snapping {
     ctx.api.fetchSourceGeometry = this.fetchSourceGeometry;
     ctx.api.fetchSourceGeometries = this.fetchSourceGeometries;
     ctx.api.getClosestPoint = this.getClosestPoint;
+    ctx.api.snapToSelectedLineForSplitEvent =
+      this.snapToSelectedLineForSplitEvent.bind(this);
+  }
+
+  /** ~max of horizontal/vertical turf distances for `snapDistance` px; used as km cap for split. */
+  _splitScreenSnapRadiusKm(mousePoint) {
+    const { x, y } = mousePoint;
+    const d = this.snapDistance;
+    const c = this.map.unproject([x, y]).toArray();
+    const p0 = turfPoint(c);
+    const hKm = turfDistance(
+      p0,
+      turfPoint(this.map.unproject([x + d, y]).toArray()),
+      { units: "kilometers" }
+    );
+    const vKm = turfDistance(
+      p0,
+      turfPoint(this.map.unproject([x, y + d]).toArray()),
+      { units: "kilometers" }
+    );
+    return Math.max(hKm, vKm, 1e-9) * 10;
+  }
+
+  /**
+   * Split tool only: snap ring / click uses the selected line geometry from the draw store.
+   * Reads the Feature's live coordinates array directly (LineString) or its aggregated
+   * getCoordinates (MultiLineString) to avoid the deep-clone cost of toGeoJSON on every
+   * throttled mousemove. Uses a geographic distance cap derived from snapDistance px so
+   * line-offset paint does not break snaps.
+   */
+  snapToSelectedLineForSplitEvent({ point: mousePoint, lngLat }) {
+    const fail = () => {
+      this.snappedFeature = null;
+      this.snappedGeometry = null;
+      this.clearSnapCoord();
+      this.map.fire("draw.snapped", { snapped: false });
+      return lngLat;
+    };
+
+    const selectedIds = this.store.getSelectedIds();
+    if (!selectedIds || !selectedIds.length) return fail();
+
+    const selectedId = selectedIds[0];
+    const drawFeat = this.store.get(selectedId);
+    if (!drawFeat) return fail();
+
+    const typ = drawFeat.type;
+    if (typ !== "LineString" && typ !== "MultiLineString") return fail();
+
+    // LineString: read the live coords array directly (no clone). MultiLineString: fall back
+    // to getCoordinates() since child-feature coords need aggregation; turf does not mutate.
+    let coords;
+    try {
+      coords = typ === "LineString" ? drawFeat.coordinates : drawFeat.getCoordinates();
+    } catch (err) {
+      return fail();
+    }
+
+    const coordsValid =
+      typ === "LineString"
+        ? Array.isArray(coords) && coords.length >= 2
+        : Array.isArray(coords) &&
+          coords.length > 0 &&
+          coords.every((line) => Array.isArray(line) && line.length >= 2);
+    if (!coordsValid) return fail();
+
+    const clickPt = turfPoint(
+      this.map.unproject([mousePoint.x, mousePoint.y]).toArray()
+    );
+
+    const lineGeom =
+      typ === "LineString" ? turfLineString(coords) : turfMultiLineString(coords);
+
+    const nearest = getNearestPointOnLine(lineGeom, clickPt, {
+      units: "kilometers",
+    });
+
+    if (
+      !nearest ||
+      nearest.properties.dist === undefined ||
+      !Number.isFinite(nearest.properties.dist)
+    ) {
+      return fail();
+    }
+
+    const maxSnapKm = this._splitScreenSnapRadiusKm(mousePoint);
+    if (nearest.properties.dist > maxSnapKm) return fail();
+
+    this.snappedGeometry = { type: typ, coordinates: coords };
+    this.snappedFeature = {
+      type: "Feature",
+      geometry: { type: typ, coordinates: coords },
+      properties: { vetro_id: selectedId },
+    };
+
+    const snapSrc = this.map.getSource("_snap_vertex");
+    if (!snapSrc) {
+      this.snappedFeature = null;
+      this.snappedGeometry = null;
+      return lngLat;
+    }
+    snapSrc.setData(turfFeatureCollection([nearest]));
+    this.map.fire("draw.snapped", { snapped: true });
+
+    const [lng, lat] = getCoord(nearest);
+    return {
+      lng,
+      lat,
+      snapped: true,
+      snappedFeature: this.snappedFeature,
+    };
   }
 
   refreshSnapLayers() {
@@ -378,10 +490,19 @@ class Snapping {
       id.match(/(polygon|linestring)$/)
     );
 
+    const mode = this.store.ctx.api.getMode();
     const selected = this.store.ctx.api.getSelected().features[0];
-    const filter = selected
-      ? ["!=", ["get", "vetro_id"], selected.id]
-      : ["all"];
+    // Compare vetro_id as strings — tiles often use numeric ids while the draw store uses strings.
+    // In split mode, only the line being split should accept a split mark.
+    // Elsewhere, exclude the active feature so vertices snap to other lines, not self.
+    let filter;
+    if (mode === SPLIT && selected) {
+      filter = ["==", ["to-string", ["get", "vetro_id"]], String(selected.id)];
+    } else if (selected) {
+      filter = ["!=", ["to-string", ["get", "vetro_id"]], String(selected.id)];
+    } else {
+      filter = ["all"];
+    }
 
     const bbox = this.getPixelBboxFromPoint({ x, y });
     // get close by linestring and polygons
@@ -453,6 +574,11 @@ class Snapping {
       [DIRECT_SELECT, SIMPLE_SELECT].includes(mode) &&
       this.store?.ctx?.map?.dragPan?._mousePan?._enabled
     ) {
+      return;
+    }
+
+    if (mode === SPLIT) {
+      this.snapToSelectedLineForSplitEvent(e);
       return;
     }
 


### PR DESCRIPTION
# [VETRO-18508](https://vetrofibermap.atlassian.net/browse/VETRO-18508)

Previously, you could put the split point on nearby lines when trying to split a line, and it would still split the originally selected line rather than the one with the split mark on it. This makes it so you can only put the split spot on the selected line, along with https://github.com/NBTSolutions/vetro-2-front-end/pull/6008 

I'm not sure if this needs to be quite so complex, but it's a fairly specific code path and it works well, so I'm inclined to not worry about it to much. 

[VETRO-18508]: https://vetrofibermap.atlassian.net/browse/VETRO-18508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ