### PR TITLE
VETRO-20732: Split tool snap to nearby point features on line

### DIFF
--- a/src/modes/split.js
+++ b/src/modes/split.js
@@ -102,12 +102,21 @@ SplitLine.onSetup = function onSetup({ featureFilter, featureId } = {}) {
 };
 
 SplitLine.onClick = async function onClick(state, e) {
-  const lngLat = await this._ctx.api.snapToSelectedLineForSplitEvent(e);
-  if (!lngLat || !lngLat.snapped) {
+  if (this._splitClickBusy) {
     return;
   }
-  const { lat, lng } = lngLat;
-  appendData(this.map, [lng, lat]);
+  this._splitClickBusy = true;
+  try {
+    const lngLat = await this._ctx.api.snapToSelectedLineForSplitEvent(e);
+    if (!lngLat || !lngLat.snapped) {
+      return;
+    }
+    const { lat, lng } = lngLat;
+    // snappedFeature on lngLat is available for future use (e.g. attributing the split to a snapped network point).
+    appendData(this.map, [lng, lat]);
+  } finally {
+    this._splitClickBusy = false;
+  }
 };
 
 // Snapping._mouseMoveHandler handles split snap on map mousemove (see SPLIT branch).

--- a/src/modes/split.js
+++ b/src/modes/split.js
@@ -101,8 +101,8 @@ SplitLine.onSetup = function onSetup({ featureFilter, featureId } = {}) {
   return { featureFilter, featureId }; // this state will be passed to future events
 };
 
-SplitLine.onClick = function onClick(state, e) {
-  const lngLat = this._ctx.api.snapToSelectedLineForSplitEvent(e);
+SplitLine.onClick = async function onClick(state, e) {
+  const lngLat = await this._ctx.api.snapToSelectedLineForSplitEvent(e);
   if (!lngLat || !lngLat.snapped) {
     return;
   }

--- a/src/snapping/index.js
+++ b/src/snapping/index.js
@@ -147,8 +147,12 @@ class Snapping {
    * getCoordinates (MultiLineString) to avoid the deep-clone cost of toGeoJSON on every
    * throttled mousemove. Uses a geographic distance cap derived from snapDistance px so
    * line-offset paint does not break snaps.
+   *
+   * When the cursor is over a rendered point feature (e.g. network points), projects that
+   * point onto the line and uses that location for the indicator and click if within snap distance.
+   * Requires the host app to expose point layers via `snapLayerFilter` / `fetchSnapGeometry`.
    */
-  snapToSelectedLineForSplitEvent({ point: mousePoint, lngLat }) {
+  async snapToSelectedLineForSplitEvent({ point: mousePoint, lngLat }) {
     const fail = () => {
       this.snappedFeature = null;
       this.snappedGeometry = null;
@@ -191,20 +195,64 @@ class Snapping {
     const lineGeom =
       typ === "LineString" ? turfLineString(coords) : turfMultiLineString(coords);
 
-    const nearest = getNearestPointOnLine(lineGeom, clickPt, {
+    const nearestFromMouse = getNearestPointOnLine(lineGeom, clickPt, {
       units: "kilometers",
     });
 
     if (
-      !nearest ||
-      nearest.properties.dist === undefined ||
-      !Number.isFinite(nearest.properties.dist)
+      !nearestFromMouse ||
+      nearestFromMouse.properties.dist === undefined ||
+      !Number.isFinite(nearestFromMouse.properties.dist)
     ) {
       return fail();
     }
 
     const maxSnapKm = this._splitScreenSnapRadiusKm(mousePoint);
-    if (nearest.properties.dist > maxSnapKm) return fail();
+    if (nearestFromMouse.properties.dist > maxSnapKm) return fail();
+
+    let nearest = nearestFromMouse;
+
+    const mapboxPointFeat = this._getClosestMapboxPoint(mousePoint.x, mousePoint.y);
+    if (mapboxPointFeat) {
+      try {
+        const pointGeom = await this.fetchSnapGeometry(mapboxPointFeat);
+        if (pointGeom && pointGeom.type === "Point") {
+          const vertexPt = turfPoint(pointGeom.coordinates);
+          const nearestFromVertex = getNearestPointOnLine(lineGeom, vertexPt, {
+            units: "kilometers",
+          });
+          if (
+            nearestFromVertex &&
+            nearestFromVertex.properties.dist !== undefined &&
+            Number.isFinite(nearestFromVertex.properties.dist) &&
+            nearestFromVertex.properties.dist <= maxSnapKm
+          ) {
+            nearest = nearestFromVertex;
+            this.snappedGeometry = pointGeom;
+            this.snappedFeature = mapboxPointFeat;
+
+            const snapSrc = this.map.getSource("_snap_vertex");
+            if (!snapSrc) {
+              this.snappedFeature = null;
+              this.snappedGeometry = null;
+              return lngLat;
+            }
+            snapSrc.setData(turfFeatureCollection([nearest]));
+            this.map.fire("draw.snapped", { snapped: true });
+
+            const [lng, lat] = getCoord(nearest);
+            return {
+              lng,
+              lat,
+              snapped: true,
+              snappedFeature: this.snappedFeature,
+            };
+          }
+        }
+      } catch (err) {
+        // fall through to mouse-nearest-on-line
+      }
+    }
 
     this.snappedGeometry = { type: typ, coordinates: coords };
     this.snappedFeature = {
@@ -578,7 +626,7 @@ class Snapping {
     }
 
     if (mode === SPLIT) {
-      this.snapToSelectedLineForSplitEvent(e);
+      await this.snapToSelectedLineForSplitEvent(e);
       return;
     }
 

--- a/src/snapping/index.js
+++ b/src/snapping/index.js
@@ -122,8 +122,8 @@ class Snapping {
       this.snapToSelectedLineForSplitEvent.bind(this);
   }
 
-  /** ~max of horizontal/vertical turf distances for `snapDistance` px; used as km cap for split. */
-  _splitScreenSnapRadiusKm(mousePoint) {
+  /** Horizontal/vertical turf distance for `snapDistance` px (no *10; used for point→line perpendicular proximity). */
+  _splitScreenSnapRadiusBaseKm(mousePoint) {
     const { x, y } = mousePoint;
     const d = this.snapDistance;
     const c = this.map.unproject([x, y]).toArray();
@@ -138,7 +138,12 @@ class Snapping {
       turfPoint(this.map.unproject([x, y + d]).toArray()),
       { units: "kilometers" }
     );
-    return Math.max(hKm, vKm, 1e-9) * 10;
+    return Math.max(hKm, vKm, 1e-9);
+  }
+
+  /** Mouse→line snap cap derived from `snapDistance` px, with *10 buffer for line-offset paint. */
+  _splitScreenSnapRadiusKm(mousePoint) {
+    return this._splitScreenSnapRadiusBaseKm(mousePoint) * 10;
   }
 
   /**
@@ -151,6 +156,8 @@ class Snapping {
    * When the cursor is over a rendered point feature (e.g. network points), projects that
    * point onto the line and uses that location for the indicator and click if within snap distance.
    * Requires the host app to expose point layers via `snapLayerFilter` / `fetchSnapGeometry`.
+   * Hosts should cache `fetchSnapGeometry` / `fetchSourceGeometries` — this runs on throttled
+   * mousemove when a point layer is under the cursor and may call into the host hook frequently.
    */
   async snapToSelectedLineForSplitEvent({ point: mousePoint, lngLat }) {
     const fail = () => {
@@ -210,10 +217,12 @@ class Snapping {
     const maxSnapKm = this._splitScreenSnapRadiusKm(mousePoint);
     if (nearestFromMouse.properties.dist > maxSnapKm) return fail();
 
+    const maxVertexToLineKm = this._splitScreenSnapRadiusBaseKm(mousePoint);
+
     let nearest = nearestFromMouse;
 
     const mapboxPointFeat = this._getClosestMapboxPoint(mousePoint.x, mousePoint.y);
-    if (mapboxPointFeat) {
+    if (mapboxPointFeat && typeof this.fetchSnapGeometry === "function") {
       try {
         const pointGeom = await this.fetchSnapGeometry(mapboxPointFeat);
         if (pointGeom && pointGeom.type === "Point") {
@@ -225,7 +234,7 @@ class Snapping {
             nearestFromVertex &&
             nearestFromVertex.properties.dist !== undefined &&
             Number.isFinite(nearestFromVertex.properties.dist) &&
-            nearestFromVertex.properties.dist <= maxSnapKm
+            nearestFromVertex.properties.dist <= maxVertexToLineKm
           ) {
             nearest = nearestFromVertex;
             this.snappedGeometry = pointGeom;
@@ -233,9 +242,7 @@ class Snapping {
 
             const snapSrc = this.map.getSource("_snap_vertex");
             if (!snapSrc) {
-              this.snappedFeature = null;
-              this.snappedGeometry = null;
-              return lngLat;
+              return fail();
             }
             snapSrc.setData(turfFeatureCollection([nearest]));
             this.map.fire("draw.snapped", { snapped: true });
@@ -263,9 +270,7 @@ class Snapping {
 
     const snapSrc = this.map.getSource("_snap_vertex");
     if (!snapSrc) {
-      this.snappedFeature = null;
-      this.snappedGeometry = null;
-      return lngLat;
+      return fail();
     }
     snapSrc.setData(turfFeatureCollection([nearest]));
     this.map.fire("draw.snapped", { snapped: true });


### PR DESCRIPTION
# [VETRO-20732](https://vetrofibermap.atlassian.net/browse/VETRO-20732)

https://github.com/NBTSolutions/vetro-2-front-end/pull/6140 is associated to this PR


https://github.com/user-attachments/assets/a5204e6f-4e8c-4cae-abda-7229dca0528d



### Author Checklist

* [ ] Review [VETRO Engineering Code Review Guidelines](https://docs.google.com/document/d/1nVK48Q6rN6WbCs6GCpCmpF042zTwqiEs4hzcf5a1OxY/edit?usp=sharing)
* [ ] Self-review and leave comments where appropriate to help guide future reviewers to critical areas
* [ ] Review the linked Jira ticket and confirm all acceptance criteria met


[VETRO-20732]: https://vetrofibermap.atlassian.net/browse/VETRO-20732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VETRO-20736]: https://vetrofibermap.atlassian.net/browse/VETRO-20736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ