### PR TITLE
Vetro 20636 point to point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+## 1.2.38
+
+- draw_point mode now snaps to existing points rendered in point-capable layers (classified in 1.2.37, including MFTH-prefixed `*-point` layer IDs) before falling back to line/polygon snapping. Orange `_snap_vertex` and click/`snapCoord` use the geometry from `fetchSnapGeometry` after a tile hit.
+
+- When finishing a draw on a snapped **point** feature, `_handlePointSnapEnd` skips `getClosestPoint`: coordinates stay at the tile-resolved/`fetchSnapGeometry` values only — no extra server refinement step (line/polygon snap-end still uses `getClosestPoint`).
+
 ## 1.2.37
 
 - Add point to point snapping for split line tool

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-draw",
-  "version": "1.2.37",
+  "version": "1.2.38",
   "description": "A drawing component for Mapbox GL JS",
   "homepage": "https://github.com/mapbox/mapbox-gl-draw",
   "author": "mapbox",

--- a/src/snapping/index.js
+++ b/src/snapping/index.js
@@ -379,8 +379,13 @@ class Snapping {
 
     let snapToFeature;
 
-    // avoid snapping points to points
-    if (this._isLineDraw()) {
+    // Line draws query point tiles first so new vertices snap to existing points.
+    // draw_point does the same, then falls back to line/polygon snapping when there is no point hit.
+    // (simple_select/coincident_select are POINT_MODEs too — we intentionally do not widen to them.)
+    if (
+      this._isLineDraw() ||
+      this.store.ctx.api.getMode() === DRAW_POINT
+    ) {
       snapToFeature = this._getClosestMapboxPoint(x, y);
     }
 
@@ -408,6 +413,9 @@ class Snapping {
   }
 
   async _handlePointSnapEnd() {
+    // Snapped-to map feature is already a Point: coords come from fetchSnapGeometry (tile/renderer
+    // pick → host geometry). We do not call getClosestPoint here — no second DB refinement for
+    // point→point snaps (unlike line/polygon verts, which refine onto the snapped feature).
     if (this._isSnappedToPoint()) return;
 
     const feature = cloneDeep(this.store.ctx.api.getAll().features[0]);

--- a/src/snapping/index.js
+++ b/src/snapping/index.js
@@ -15,6 +15,7 @@ const {
   deepFlatten,
   isMultiGeometry,
 } = require("./util");
+const { isSnapPointLayerId } = require("./is_snap_point_layer_id");
 const {
   STATIC,
   FREEHAND,
@@ -526,7 +527,7 @@ class Snapping {
   }
 
   _getClosestMapboxPoint(x, y) {
-    const pointIds = this.snapLayers.filter((id) => id.endsWith("point"));
+    const pointIds = this.snapLayers.filter(isSnapPointLayerId);
 
     const bbox = this.getPixelBboxFromPoint({ x, y });
 

--- a/src/snapping/is_snap_point_layer_id.js
+++ b/src/snapping/is_snap_point_layer_id.js
@@ -1,0 +1,84 @@
+/**
+ * Resolves Vetros mfth_<mapboxLayerId>_<previewOwner> wrapper to the embedded mapbox
+ * layer id (see vetro-2-front-end formatMapboxLayerId).
+ *
+ * @param {string} id
+ * @returns {string}
+ */
+function getSnapLayerBasename(id) {
+  if (!id.startsWith("mfth_")) {
+    return id;
+  }
+
+  const withoutPrefix = id.slice(5);
+  const lastSep = withoutPrefix.lastIndexOf("_");
+
+  if (lastSep <= 0) {
+    return withoutPrefix;
+  }
+
+  return withoutPrefix.slice(0, lastSep);
+}
+
+/** Line / polygon tails used for snapping non-point geometries (mirror _getClosestLineStringOrPolygon). */
+const NON_POINT_GEOMETRY_TAIL =
+  /-(?:linestring|polygon|dottedlinestring|guidelinedottedlinestring)$/i;
+
+/**
+ * Same geometry capture as vetro-2-front-end getLayerTypeFromMapboxLayerId for ids that match
+ * the mapbox-layer / nested mfth template.
+ */
+const VETRO_EMBEDDED_GEOMETRY_SEGMENT =
+  /(?:mapbox-layer[-_]-?\d+[-_]|mfth[-_]\w+[-_]-?\d+[-_])(point|linestring|polygon|dottedlinestring|guidelinedottedlinestring)/i;
+
+/**
+ * True when `id` denotes a rendered point geometry layer suitable for point snap queries.
+ * Decorative layers (_label / _icon) are excluded where possible; hosts still rely on snapLayerFilter.
+ *
+ * @param {string} id
+ * @returns {boolean}
+ */
+function isSnapPointLayerId(id) {
+  if (typeof id !== "string" || id.length === 0) {
+    return false;
+  }
+
+  const fullLower = id.toLowerCase();
+  if (fullLower.endsWith("_label") || fullLower.endsWith("_icon")) {
+    return false;
+  }
+
+  const basename = getSnapLayerBasename(id);
+  if (!basename.length) {
+    return false;
+  }
+
+  const baseLower = basename.toLowerCase();
+  if (baseLower.includes("label")) {
+    return false;
+  }
+
+  if (NON_POINT_GEOMETRY_TAIL.test(basename)) {
+    return false;
+  }
+
+  // Only interpret the Vetros geometry fragment when the basename is actually a
+  // mapbox-layer / mfth-prefixed layer id (avoid matching spurious "…_mfth_…"
+  // segments inside unrelated ids).
+  const useEmbeddedFragment =
+    basename.startsWith("mapbox-layer") || basename.startsWith("mfth_");
+  if (useEmbeddedFragment) {
+    const embedded = basename.match(VETRO_EMBEDDED_GEOMETRY_SEGMENT);
+    if (embedded) {
+      return embedded[1].toLowerCase() === "point";
+    }
+  }
+
+  // circle-… , polygon-outline-… , dashed-line-… convention: basename ends with "point".
+  return baseLower.endsWith("point");
+}
+
+module.exports = {
+  getSnapLayerBasename,
+  isSnapPointLayerId,
+};

--- a/test/is_snap_point_layer_id.test.js
+++ b/test/is_snap_point_layer_id.test.js
@@ -1,0 +1,89 @@
+import test from 'tape';
+import {
+  getSnapLayerBasename,
+  isSnapPointLayerId,
+} from '../src/snapping/is_snap_point_layer_id';
+
+test('getSnapLayerBasename', (t) => {
+  const cases = [
+    { id: 'circle-123-point', want: 'circle-123-point' },
+    {
+      id: 'mfth_circle-network-999-point_myOwnerKey',
+      want: 'circle-network-999-point',
+    },
+    { id: 'mfth_mapbox-layer-1-point_u1', want: 'mapbox-layer-1-point' },
+  ];
+
+  cases.forEach(({ id, want }) => {
+    t.equal(getSnapLayerBasename(id), want, `'${id}' basename`);
+  });
+  t.end();
+});
+
+test('isSnapPointLayerId', (t) => {
+  const positive = [
+    'circle-network-123-point',
+    'polygon-outline-42-point',
+    'dashed-line-7-point',
+    // mapbox-layer-{digits}_ + vetro embedding regex
+    'mapbox-layer--1_-point',
+    'mapbox-layer-901-point',
+
+    // MFTH: preview owner trailing segment; basename must encode point geometry.
+    'mfth_circle-network-123-point_previewOwner',
+    'mfth_mapbox-layer-902-point_xyz',
+    'mfth_mfth_abc_-999_-point_own',
+
+    // Inner mapbox-like id strings may nest mfth-looking segments; outer mfth still peels owner.
+    'mfth_mfth_w_-999_-999_-point_previewOwner123',
+  ];
+
+  const negative = [
+    'polygon-outline-linestring-feature',
+    'mapbox-layer-2-linestring',
+    'fancy-thing-polygon',
+
+    '',
+    'not-a-map-layer',
+
+    // Non-point Vetros tails
+    'trail-dottedlinestring',
+    'road-guidelinedottedlinestring',
+
+    // Decorative trailers on full layer id
+    'circle-888-point_some_label',
+    'circle-777-point_icons_icon',
+    'polygon-outline-extra_point_icon',
+    'polygon-outline-extra_icons_label',
+    'whatever_label',
+    'whatever_icon',
+    'polygon-outline-extra_point_label',
+    'circle-123-point_text_label',
+
+    // Polygon / linestring basenames after mfth unwrap
+
+    'mfth_polygon-outline-linestring-tail-polygon_own',
+    'mfth_mapbox-layer-3-linestring_x',
+    'mfth_mapbox-layer-303-polygon_x',
+
+    // Label-like basename
+    'mapbox-layer-1-feature-label-marker',
+    'mfth_mapbox-layer-1-point-label-marker_own',
+    'polygon-outline-area-label-extra',
+
+    // Not outer Vetros mfth wrapper — last '_' is part of basename, no owner peel.
+
+    'prefix_mfth_circle-1-point_ownerXYZ',
+    'blah_mfth_w_-1_-999_-point_own',
+  ];
+
+  positive.forEach((id) =>
+    t.ok(isSnapPointLayerId(id), `expected POINT: '${id}'`)
+  );
+
+  negative.forEach((id) =>
+    t.notOk(isSnapPointLayerId(id), `expected non-point: '${id}'`)
+  );
+
+  t.end();
+});

--- a/test/snapping_draw_point.test.js
+++ b/test/snapping_draw_point.test.js
@@ -1,0 +1,128 @@
+import test from 'tape';
+import Snapping from '../src/snapping/index';
+import Constants from '../src/constants';
+
+const { DRAW_POINT } = Constants.modes;
+
+// getPixelBboxFromPoint reads devicePixelRatio; mock-browser omits it.
+global.window.devicePixelRatio = 1;
+
+function createMockCtx(mode) {
+  const pointFeatureHit = {
+    type: 'Feature',
+    geometry: { type: 'Point', coordinates: [-122.4, 37.81] },
+    properties: { vetro_id: 'target-xyz' },
+    id: 'mb-1',
+    source: 'vector-tiles',
+  };
+
+  /** Set when `_getClosestMapboxPoint` runs `queryRenderedFeatures` against point-layer ids */
+  let pointLayerPassQueryLayers;
+
+  const map = {
+    on: () => {},
+    off: () => {},
+    fire: () => {},
+    getStyle: () => ({
+      layers: [{ id: 'circle-network-9-point', type: 'circle' }],
+    }),
+    queryRenderedFeatures: (_bbox, opts) => {
+      const layers = opts && opts.layers ? opts.layers : [];
+      if (layers.includes('circle-network-9-point')) {
+        pointLayerPassQueryLayers = layers.slice();
+        return [pointFeatureHit];
+      }
+      return [];
+    },
+    setFeatureState: () => {},
+    getSource: () => ({
+      _data: { features: [] },
+      setData: () => {},
+    }),
+    addSource: () => {},
+    addLayer: () => {},
+    getLayer: () => null,
+    removeLayer: () => {},
+    removeSource: () => {},
+    unproject: () => ({
+      toArray: () => [-122.5, 37.82],
+    }),
+  };
+
+  const api = {
+    getMode: () => mode,
+    getSelected: () => ({ features: [] }),
+    getSelectedPoints: () => ({ features: [] }),
+    getAll: () => ({ features: [] }),
+    set: () => {},
+  };
+
+  const ctx = {
+    map,
+    store: { ctx: null },
+    api,
+    options: {
+      snapLayerFilter: (layer) => /(?:^|-)point(?:$|-)/.test(layer.id),
+      snapDistance: 20,
+      fetchSnapGeometry: async (feat) => (
+        feat === pointFeatureHit
+          ? { type: 'Point', coordinates: [-100, 41] }
+          : null
+      ),
+      fetchSnapGeometries: async () => [],
+      getClosestPoint: async () => ({
+        type: 'Point',
+        coordinates: [0, 0],
+      }),
+      resetSnappingGeomCache: () => {},
+      _updateSourceGeomCache: () => {},
+      _setGeomCacheIfNotExists: () => {},
+      fetchSourceGeometry: () => {},
+      fetchSourceGeometries: () => {},
+      fetchMapExtentGeometry: () => {},
+    },
+  };
+
+  ctx.store.ctx = ctx;
+
+  return {
+    ctx,
+    pointFeatureHit,
+    getPointLayerPassQueryLayers: () => pointLayerPassQueryLayers,
+  };
+}
+
+test('_setSnappedFeature: draw_point queries point-capable layers and uses fetchSnapGeometry', (t) => {
+  const { ctx, pointFeatureHit, getPointLayerPassQueryLayers } = createMockCtx(
+    DRAW_POINT
+  );
+  const snapping = new Snapping(ctx);
+  snapping.snapLayers = ['circle-network-9-point'];
+
+  snapping._setSnappedFeature({ point: { x: 100, y: 200 } }).then(() => {
+    const layers = getPointLayerPassQueryLayers();
+
+    t.ok(
+      Array.isArray(layers) && layers.includes('circle-network-9-point'),
+      'point pass queries snap point layer ids'
+    );
+
+    t.deepEqual(
+      snapping.snappedGeometry,
+      { type: 'Point', coordinates: [-100, 41] },
+      'geometry from fetchSnapGeometry after tile hit'
+    );
+    t.equal(
+      snapping.snappedFeature,
+      pointFeatureHit,
+      'snap target is queried feature'
+    );
+
+    snapping.disableSnapping();
+    t.end();
+  }).catch((err) => {
+    snapping.disableSnapping();
+    t.error(err);
+    t.end();
+  });
+});


### PR DESCRIPTION
[VETRO-20636](https://vetrofibermap.atlassian.net/browse/VETRO-20636)

- Fix which Vetro layer IDs are used for point queryRenderedFeatures (MFTH mfth_<id>_<owner> peeling; no more endsWith("point") only).
- In draw_point, _setSnappedFeature now runs _getClosestMapboxPoint first (same as line draw), then falls back to line/polygon. simple_select / coincident_select unchanged.
- Point→point finish: _handlePointSnapEnd still skips getClosestPoint when snapped to a Point (fetchSnapGeometry only); line/polygon verteces unchanged.

Follow-up
vetro-2-front-end: pin #v1.2.38 + lockfile after tag is up.

[VETRO-20636]: https://vetrofibermap.atlassian.net/browse/VETRO-20636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ